### PR TITLE
fix(shared): Replace median clone with in-place quickselect to reduce gas consumption on Soroban

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -145,32 +145,69 @@ pub fn calculate_amount_after_fee(amount: i128, fee_rate_bps: i128) -> i128 {
     amount - calculate_fee(amount, fee_rate_bps)
 }
 
-/// Calculate median of sorted values
-pub fn median(values: soroban_sdk::Vec<i128>) -> Option<i128> {
+/// Calculate median using in-place quickselect algorithm
+/// This avoids unnecessary allocations (clone) and reduces gas consumption
+pub fn median(mut values: soroban_sdk::Vec<i128>) -> Option<i128> {
     if values.is_empty() {
         return None;
     }
 
-    let mut sorted = values.clone();
-    let n = sorted.len();
-    for i in 0..n {
-        for j in 0..n - 1 - i {
-            let v1 = sorted.get(j).unwrap();
-            let v2 = sorted.get(j + 1).unwrap();
-            if v1 > v2 {
-                sorted.set(j, v2);
-                sorted.set(j + 1, v1);
-            }
+    let n = values.len();
+    let mid = n / 2;
+
+    if n % 2 == 0 {
+        // For even count, find two middle elements and average them
+        let _ = quickselect_inplace(&mut values, 0, (n - 1) as i32, (mid - 1) as i32);
+        let val1 = values.get(mid - 1)?;
+        let _ = quickselect_inplace(&mut values, 0, (n - 1) as i32, mid as i32);
+        let val2 = values.get(mid)?;
+        Some((val1 + val2) / 2)
+    } else {
+        // For odd count, find the middle element
+        let _ = quickselect_inplace(&mut values, 0, (n - 1) as i32, mid as i32);
+        Some(values.get(mid)?)
+    }
+}
+
+/// In-place quickselect to find the k-th smallest element
+/// Based on Hoare's selection algorithm for O(n) average performance without cloning
+fn quickselect_inplace(values: &mut soroban_sdk::Vec<i128>, mut left: i32, mut right: i32, k: i32) {
+    while left < right {
+        let pivot_index = partition_inplace(values, left, right);
+        if k == pivot_index {
+            return;
+        } else if k < pivot_index {
+            right = pivot_index - 1;
+        } else {
+            left = pivot_index + 1;
+        }
+    }
+}
+
+/// Partition array in-place for quickselect using Lomuto partition scheme
+fn partition_inplace(values: &mut soroban_sdk::Vec<i128>, left: i32, right: i32) -> i32 {
+    let pivot_value = values.get(right as usize).unwrap_or(0);
+    let mut i = left - 1;
+
+    for j in left..right {
+        let val_j = values.get(j as usize).unwrap_or(0);
+        if val_j < pivot_value {
+            i += 1;
+            let idx_i = i as usize;
+            let idx_j = j as usize;
+            let val_i = values.get(idx_i).unwrap_or(0);
+            values.set(idx_i, val_j);
+            values.set(idx_j, val_i);
         }
     }
 
-    let mid = n / 2;
-    #[allow(clippy::manual_is_multiple_of)]
-    if n % 2 == 0 {
-        Some((sorted.get(mid - 1).unwrap() + sorted.get(mid).unwrap()) / 2)
-    } else {
-        Some(sorted.get(mid).unwrap())
-    }
+    let idx_i_plus_1 = (i + 1) as usize;
+    let idx_right = right as usize;
+    let val_i_plus_1 = values.get(idx_i_plus_1).unwrap_or(0);
+    values.set(idx_i_plus_1, pivot_value);
+    values.set(idx_right, val_i_plus_1);
+
+    i + 1
 }
 
 /// Calculate percentage deviation


### PR DESCRIPTION
Close #99 

# Fix: Optimize median calculation with in-place quickselect algorithm

## Description
Resolves **C-020 — median allocates via to_vec() in shared util** by replacing the inefficient clone-based bubble sort implementation with an in-place quickselect algorithm.

## Problem
- The original `median()` function in `shared/src/lib.rs` was using `values.clone()` internally
- Implementation used O(n²) bubble sort to sort the entire array
- This caused unnecessary memory allocations and exceeded gas budgets on Soroban's `no_std` environment

## Solution
- Implemented in-place quickselect algorithm (O(n) average time complexity)
- Eliminated unnecessary vector cloning
- Reduced memory footprint and gas consumption
- Maintains binary-compatible API and identical results

## Changes
- `shared/src/lib.rs`:
  - Optimized `median()` function to take ownership of input vector
  - Added `quickselect_inplace()` helper function using Hoare's selection algorithm
  - Added `partition_inplace()` helper function using Lomuto partition scheme

## Technical Details
- **Odd-length arrays:** Finds the middle element directly
- **Even-length arrays:** Averages the two middle elements (after selection)
- **Average time complexity:** O(n) vs original O(n²)
- **Space complexity:** O(1) in-place vs original O(n) for clone

## Testing
- Implementation verified to work correctly with oracle tests
- Median calculation for [1230000, 1235000, 1239000] correctly returns 1235000
- All contract functionality remains unchanged

## Impact
- ✅ Reduced gas consumption on Soroban contracts
- ✅ Improved performance of rate aggregation in oracle contract
- ✅ Maintains contract compatibility and correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized median calculation for improved efficiency and faster computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->