### PR TITLE
Fix assigned escrow, savings, burning, and oracle issues

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, Env, IntoVal, String as SorobanString,
-    Symbol, Vec, BytesN,
+    contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env, IntoVal,
+    String as SorobanString, Symbol, Vec,
 };
 
 use shared::{calculate_fee, BurnEvent, CurrencyCode, BASIS_POINTS, DECIMALS, MIN_BURN_AMOUNT};
@@ -183,7 +183,12 @@ impl BurningContract {
     }
 
     /// Redeem ACBU for proportional Afreum S-tokens across the basket (lower fee tier).
-    pub fn redeem_basket(env: Env, user: Address, recipient: Address, acbu_amount: i128) -> Vec<i128> {
+    pub fn redeem_basket(
+        env: Env,
+        user: Address,
+        recipient: Address,
+        acbu_amount: i128,
+    ) -> Vec<i128> {
         Self::check_paused(&env);
         user.require_auth();
 
@@ -221,8 +226,24 @@ impl BurningContract {
         );
 
         let mut amounts_out = Vec::new(&env);
+        let mut last_weighted_idx: Option<u32> = None;
+        for i in 0..currencies.len() {
+            let currency = currencies.get(i).unwrap();
+            let weight: i128 = env.invoke_contract(
+                &oracle_addr,
+                &Symbol::new(&env, "get_basket_weight"),
+                vec![&env, currency.into_val(&env)],
+            );
+            if weight > 0 {
+                last_weighted_idx = Some(i);
+            }
+        }
 
-        for currency in currencies.iter() {
+        let mut usd_allocated = 0i128;
+        let mut fee_allocated = 0i128;
+
+        for i in 0..currencies.len() {
+            let currency = currencies.get(i).unwrap();
             let weight: i128 = env.invoke_contract(
                 &oracle_addr,
                 &Symbol::new(&env, "get_basket_weight"),
@@ -248,10 +269,16 @@ impl BurningContract {
                 vec![&env, currency.clone().into_val(&env)],
             );
 
-            let usd_i = (weight * usd_total) / BASIS_POINTS;
+            let (usd_i, fee_i) = if Some(i) == last_weighted_idx {
+                (usd_total - usd_allocated, total_fee - fee_allocated)
+            } else {
+                let usd_i = (weight * usd_total) / BASIS_POINTS;
+                let fee_i = (weight * total_fee) / BASIS_POINTS;
+                usd_allocated += usd_i;
+                fee_allocated += fee_i;
+                (usd_i, fee_i)
+            };
             let native_i = (usd_i * DECIMALS) / rate;
-
-            let fee_i = (weight * total_fee) / BASIS_POINTS;
 
             if native_i > 0 {
                 let token = soroban_sdk::token::Client::new(&env, &stoken);
@@ -317,7 +344,10 @@ impl BurningContract {
     }
 
     pub fn get_fee_single_redeem(env: Env) -> i128 {
-        env.storage().instance().get(&DATA_KEY.fee_single_redeem).unwrap()
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.fee_single_redeem)
+            .unwrap()
     }
 
     pub fn is_paused(env: Env) -> bool {

--- a/acbu_burning/tests/test.rs
+++ b/acbu_burning/tests/test.rs
@@ -2,11 +2,7 @@
 
 use acbu_burning::{BurningContract, BurningContractClient};
 use shared::{CurrencyCode, DECIMALS};
-use soroban_sdk::{
-    contract, contractimpl, symbol_short,
-    testutils::{Address as _},
-    Address, Env,
-};
+use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Address as _, Address, Env};
 
 mod oracle_mock {
     use super::*;
@@ -25,11 +21,19 @@ mod oracle_mock {
         pub fn get_currencies(env: Env) -> Vec<CurrencyCode> {
             let mut v = Vec::new(&env);
             v.push_back(CurrencyCode::new(&env, "NGN"));
+            v.push_back(CurrencyCode::new(&env, "KES"));
+            v.push_back(CurrencyCode::new(&env, "GHS"));
             v
         }
 
-        pub fn get_basket_weight(_env: Env, _c: CurrencyCode) -> i128 {
-            10_000
+        pub fn get_basket_weight(env: Env, c: CurrencyCode) -> i128 {
+            if c == CurrencyCode::new(&env, "NGN") || c == CurrencyCode::new(&env, "KES") {
+                3_333
+            } else if c == CurrencyCode::new(&env, "GHS") {
+                3_334
+            } else {
+                0
+            }
         }
 
         pub fn get_rate(_env: Env, _c: CurrencyCode) -> i128 {
@@ -56,7 +60,9 @@ fn test_burning_initialize_and_version() {
     let admin = Address::generate(&env);
     let oracle = env.register_contract(None, oracle_mock::MockOracle);
     let reserve_tracker = Address::generate(&env);
-    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let withdrawal_processor = Address::generate(&env);
     let vault = admin.clone();
 
@@ -91,8 +97,12 @@ fn test_redeem_single_transfers_stoken() {
     let oracle = env.register_contract(None, oracle_mock::MockOracle);
     let reserve_tracker = Address::generate(&env);
 
-    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
-    let stoken = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let stoken = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
 
     oracle_mock::MockOracleClient::new(&env, &oracle).seed_stoken(&stoken);
 
@@ -141,8 +151,12 @@ fn test_redeem_basket() {
     let oracle = env.register_contract(None, oracle_mock::MockOracle);
     let reserve_tracker = Address::generate(&env);
 
-    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
-    let stoken = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let stoken = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
 
     oracle_mock::MockOracleClient::new(&env, &oracle).seed_stoken(&stoken);
 
@@ -162,7 +176,7 @@ fn test_redeem_basket() {
     );
 
     let acbu_sac = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
-    let burn_amt = 100 * DECIMALS;
+    let burn_amt = 100 * DECIMALS + 3;
     acbu_sac.mint(&user, &burn_amt);
 
     let st_sac = soroban_sdk::token::StellarAssetClient::new(&env, &stoken);
@@ -173,5 +187,12 @@ fn test_redeem_basket() {
     token.approve(&vault, &contract_id, &1_000_000_000_000_000, &100u32);
 
     let amounts = client.redeem_basket(&user, &recipient, &burn_amt);
-    assert!(!amounts.is_empty());
+    assert_eq!(amounts.len(), 3);
+
+    let mut total_out = 0i128;
+    for amount in amounts.iter() {
+        total_out += amount;
+    }
+    let expected_fee = (burn_amt * 100) / 10_000;
+    assert_eq!(total_out + expected_fee, burn_amt);
 }

--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
-
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol,
+};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -19,7 +20,6 @@ const DATA_KEY: DataKey = DataKey {
 };
 
 const VERSION: u32 = 1;
-
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -123,7 +123,7 @@ impl Escrow {
         Ok(())
     }
 
-    /// Release escrow: payee receives ACBU (caller must be admin or authorized)
+    /// Release escrow: payee receives ACBU (payer authorization required)
     /// caller must supply payer and escrow_id to identify which escrow to release
     pub fn release(env: Env, escrow_id: u64, payer: Address) -> Result<(), soroban_sdk::Error> {
         let paused: bool = env
@@ -135,20 +135,17 @@ impl Escrow {
             return Err(soroban_sdk::Error::from_contract_error(3001));
         }
 
-        // only admain can trigger release
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.admin)
-            .expect("admin not set — contract not initialized");
-        admin.require_auth();
+        payer.require_auth();
 
         let key = EscrowId(payer.clone(), escrow_id);
-        let (_stored_payer, payee, amount): (Address, Address, i128) = env
+        let (stored_payer, payee, amount): (Address, Address, i128) = env
             .storage()
             .temporary()
             .get(&key)
             .ok_or(soroban_sdk::Error::from_contract_error(3003))?;
+        if stored_payer != payer {
+            return Err(soroban_sdk::Error::from_contract_error(3004));
+        }
 
         let acbu: Address = env
             .storage()
@@ -268,4 +265,3 @@ impl Escrow {
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 }
-

--- a/acbu_escrow/tests/test.rs
+++ b/acbu_escrow/tests/test.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use acbu_escrow::{Escrow, EscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+#[test]
+fn test_unauthorized_release_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let escrow_id = 42u64;
+    let amount = 10_000_000i128;
+
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    env.mock_all_auths();
+    token_admin.mint(&payer, &amount);
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+    client.create(&payer, &payee, &amount, &escrow_id);
+
+    // Only attacker auth is provided; release() requires payer auth.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "release",
+            args: (escrow_id, payer.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = client.try_release(&escrow_id, &payer);
+    assert!(result.is_err(), "Release without payer auth must fail");
+}
+
+#[test]
+fn test_payer_can_release() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let escrow_id = 99u64;
+    let amount = 12_500_000i128;
+
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    env.mock_all_auths();
+    token_admin.mint(&payer, &amount);
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+    client.create(&payer, &payee, &amount, &escrow_id);
+
+    env.mock_auths(&[MockAuth {
+        address: &payer,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "release",
+            args: (escrow_id, payer.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.release(&escrow_id, &payer);
+
+    let token = soroban_sdk::token::Client::new(&env, &acbu_token);
+    assert_eq!(token.balance(&payee), amount);
+}

--- a/acbu_oracle/tests/test.rs
+++ b/acbu_oracle/tests/test.rs
@@ -156,9 +156,9 @@ fn test_outlier_detection() {
     let mut sources = Vec::new(&env);
     // Create sources with one significant outlier
     // Median will be around 1000000
-    sources.push_back(1000000i128);   // Normal
-    sources.push_back(1005000i128);   // Normal
-    sources.push_back(1350000i128);   // Outlier (>3% deviation)
+    sources.push_back(1000000i128); // Normal
+    sources.push_back(1005000i128); // Normal
+    sources.push_back(1350000i128); // Outlier (>3% deviation)
 
     client.update_rate(&validator, &ngn, &rate, &sources, &env.ledger().timestamp());
 
@@ -177,7 +177,7 @@ fn test_outlier_detection() {
         let topics = event.1;
         if !topics.is_empty() {
             let event_symbol = Symbol::from_val(&env, &topics.get(0).unwrap());
-            
+
             if event_symbol == symbol_short!("rate_upd") {
                 rate_update_found = true;
             } else if event_symbol == symbol_short!("outlier") {
@@ -191,8 +191,79 @@ fn test_outlier_detection() {
             }
         }
     }
-    
+
     assert!(rate_update_found, "expected rate_upd event");
     assert!(outlier_found, "expected outlier detection event");
 }
 
+#[test]
+fn test_update_rate_uses_even_source_median_average() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let mut sources = Vec::new(&env);
+    sources.push_back(1000000i128);
+    sources.push_back(1020000i128);
+    sources.push_back(980000i128);
+    sources.push_back(1040000i128);
+
+    client.update_rate(
+        &validator,
+        &ngn,
+        &1234567i128,
+        &sources,
+        &env.ledger().timestamp(),
+    );
+    let stored_rate = client.get_rate(&ngn);
+    // Sorted = [980000, 1000000, 1020000, 1040000], median = (1000000 + 1020000) / 2
+    assert_eq!(stored_rate, 1010000);
+}
+
+#[test]
+fn test_update_rate_falls_back_to_provided_rate_when_sources_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let sources = Vec::new(&env);
+    let submitted_rate = 1_111_111i128;
+    client.update_rate(
+        &validator,
+        &ngn,
+        &submitted_rate,
+        &sources,
+        &env.ledger().timestamp(),
+    );
+    assert_eq!(client.get_rate(&ngn), submitted_rate);
+}

--- a/acbu_savings_vault/tests/test.rs
+++ b/acbu_savings_vault/tests/test.rs
@@ -39,7 +39,8 @@ fn test_withdraw_after_term_has_zero_yield_at_deposit_time() {
     client.deposit(&user, &deposit_amount, &term_seconds);
 
     // Advance time past the lock term so the withdrawal is valid
-    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
+    env.ledger()
+        .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
 
     client.withdraw(&user, &term_seconds, &deposit_amount);
 
@@ -228,11 +229,53 @@ fn test_withdraw_at_exact_term_boundary_succeeds() {
     client.deposit(&user, &deposit_amount, &term_seconds);
 
     // Advance to exactly term boundary
-    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
+    env.ledger()
+        .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
 
     client.withdraw(&user, &term_seconds, &deposit_amount);
 
     let token_client = soroban_sdk::token::Client::new(&env, &acbu_token);
     assert_eq!(token_client.balance(&user), deposit_amount);
     assert_eq!(client.get_balance(&user, &term_seconds), 0);
+}
+
+#[test]
+fn test_withdraw_only_uses_lots_that_reached_their_own_term() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register_contract(None, SavingsVault);
+    let client = SavingsVaultClient::new(&env, &contract_id);
+    client.initialize(&admin, &acbu_token, &0i128, &0i128);
+
+    let short_term: u64 = 60;
+    let long_term: u64 = 3_600;
+    let short_amount = 5_000_000i128;
+    let long_amount = 7_000_000i128;
+
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    token_admin.mint(&user, &(short_amount + long_amount));
+
+    client.deposit(&user, &short_amount, &short_term);
+    client.deposit(&user, &long_amount, &long_term);
+
+    // Only the short-term lot is mature.
+    env.ledger()
+        .with_mut(|l| l.timestamp = 1_000_000 + short_term);
+
+    // Short-term withdrawal succeeds.
+    client.withdraw(&user, &short_term, &short_amount);
+    assert_eq!(client.get_balance(&user, &short_term), 0);
+
+    // Long-term withdrawal still fails because its own term has not elapsed.
+    let early_long = client.try_withdraw(&user, &long_term, &long_amount);
+    assert!(early_long.is_err());
+    assert_eq!(client.get_balance(&user, &long_term), long_amount);
 }


### PR DESCRIPTION
## Summary
- fix `acbu_escrow::release` authorization by requiring payer auth and add escrow auth regression tests
- prevent basket redemption dust loss by allocating USD/fee remainders to the last weighted currency slice in `acbu_burning`
- strengthen `acbu_oracle` median test coverage (even-count median + empty-source fallback) and add savings term-enforcement regression coverage
- validate all changes with targeted package tests for escrow, savings vault, burning, and oracle

## Linked issues
Closes #80
Closes #86
Closes #88
Closes #97

## Test plan
- [x] `cargo test -p acbu_escrow -p acbu_savings_vault -p acbu_burning -p acbu_oracle`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy in basket redemption allocations by fixing rounding issues.
  * Updated escrow release authorization to require payer verification instead of admin approval.

* **New Features**
  * Enhanced savings vault withdrawal logic to respect individual deposit maturity terms.

* **Tests**
  * Added comprehensive integration tests for escrow authorization and payer release flows.
  * Extended test coverage for oracle rate calculations and savings vault deposit maturity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->