### PR TITLE
fix(escrow): remove panic-prone storage reads and add negative tests

### DIFF
--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -20,6 +20,13 @@ const DATA_KEY: DataKey = DataKey {
 };
 
 const VERSION: u32 = 1;
+const ERR_PAUSED: u32 = 3001;
+const ERR_INVALID_AMOUNT: u32 = 3002;
+const ERR_ESCROW_NOT_FOUND: u32 = 3003;
+const ERR_PAYER_MISMATCH: u32 = 3004;
+const ERR_ESCROW_EXISTS: u32 = 3005;
+const ERR_UNINITIALIZED_ADMIN: u32 = 3006;
+const ERR_UNINITIALIZED_ACBU_TOKEN: u32 = 3007;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -58,6 +65,24 @@ pub struct Escrow;
 
 #[contractimpl]
 impl Escrow {
+    fn get_admin(env: &Env) -> Result<Address, soroban_sdk::Error> {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.admin)
+            .ok_or(soroban_sdk::Error::from_contract_error(
+                ERR_UNINITIALIZED_ADMIN,
+            ))
+    }
+
+    fn get_acbu_token(env: &Env) -> Result<Address, soroban_sdk::Error> {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.acbu_token)
+            .ok_or(soroban_sdk::Error::from_contract_error(
+                ERR_UNINITIALIZED_ACBU_TOKEN,
+            ))
+    }
+
     /// Initialize the escrow contract
     pub fn initialize(env: Env, admin: Address, acbu_token: Address) {
         if env.storage().instance().has(&DATA_KEY.admin) {
@@ -86,23 +111,19 @@ impl Escrow {
             .get(&DATA_KEY.paused)
             .unwrap_or(false);
         if paused {
-            return Err(soroban_sdk::Error::from_contract_error(3001));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_PAUSED));
         }
         if amount <= 0 {
-            return Err(soroban_sdk::Error::from_contract_error(3002));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_INVALID_AMOUNT));
         }
         payer.require_auth();
         let key = EscrowId(payer.clone(), escrow_id);
 
         if env.storage().temporary().has(&key) {
-            return Err(soroban_sdk::Error::from_contract_error(3005));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_ESCROW_EXISTS));
         }
 
-        let acbu: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.acbu_token)
-            .expect("acbu_token not set — contract not initialized");
+        let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
         client.transfer(&payer, &env.current_contract_address(), &amount);
 
@@ -132,7 +153,7 @@ impl Escrow {
             .get(&DATA_KEY.paused)
             .unwrap_or(false);
         if paused {
-            return Err(soroban_sdk::Error::from_contract_error(3001));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_PAUSED));
         }
 
         payer.require_auth();
@@ -142,16 +163,12 @@ impl Escrow {
             .storage()
             .temporary()
             .get(&key)
-            .ok_or(soroban_sdk::Error::from_contract_error(3003))?;
+            .ok_or(soroban_sdk::Error::from_contract_error(ERR_ESCROW_NOT_FOUND))?;
         if stored_payer != payer {
-            return Err(soroban_sdk::Error::from_contract_error(3004));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_PAYER_MISMATCH));
         }
 
-        let acbu: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.acbu_token)
-            .expect("acbu_token not set — contract not initialized");
+        let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
         client.transfer(&env.current_contract_address(), &payee, &amount);
 
@@ -172,11 +189,7 @@ impl Escrow {
     /// Refund escrow: payer gets ACBU back (admin or dispute resolution)
     /// key is same as release since it identifies which escrow to refund
     pub fn refund(env: Env, escrow_id: u64, payer: Address) -> Result<(), soroban_sdk::Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.admin)
-            .expect("admin not set — contract not initialized");
+        let admin = Self::get_admin(&env)?;
         admin.require_auth();
 
         let key = EscrowId(payer.clone(), escrow_id);
@@ -184,17 +197,13 @@ impl Escrow {
             .storage()
             .temporary()
             .get(&key)
-            .ok_or(soroban_sdk::Error::from_contract_error(3003))?;
+            .ok_or(soroban_sdk::Error::from_contract_error(ERR_ESCROW_NOT_FOUND))?;
 
         if stored_payer != payer {
-            return Err(soroban_sdk::Error::from_contract_error(3004));
+            return Err(soroban_sdk::Error::from_contract_error(ERR_PAYER_MISMATCH));
         }
 
-        let acbu: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.acbu_token)
-            .expect("acbu_token not set — contract not initialized");
+        let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
         client.transfer(&env.current_contract_address(), &payer, &amount);
 
@@ -213,22 +222,14 @@ impl Escrow {
     }
 
     pub fn pause(env: Env) -> Result<(), soroban_sdk::Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.admin)
-            .expect("admin not set — contract not initialized");
+        let admin = Self::get_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &true);
         Ok(())
     }
 
     pub fn unpause(env: Env) -> Result<(), soroban_sdk::Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.admin)
-            .expect("admin not set — contract not initialized");
+        let admin = Self::get_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &false);
         Ok(())

--- a/acbu_escrow/tests/test.rs
+++ b/acbu_escrow/tests/test.rs
@@ -3,7 +3,7 @@
 use acbu_escrow::{Escrow, EscrowClient};
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
-    Address, Env, IntoVal,
+    Address, Env, Error, IntoVal,
 };
 
 #[test]
@@ -78,4 +78,52 @@ fn test_payer_can_release() {
 
     let token = soroban_sdk::token::Client::new(&env, &acbu_token);
     assert_eq!(token.balance(&payee), amount);
+}
+
+#[test]
+fn test_release_missing_escrow_returns_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+
+    let result = client.try_release(&1u64, &payer);
+    assert_eq!(result, Err(Ok(Error::from_contract_error(3003))));
+}
+
+#[test]
+fn test_refund_missing_escrow_returns_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+
+    let result = client.try_refund(&1u64, &payer);
+    assert_eq!(result, Err(Ok(Error::from_contract_error(3003))));
+}
+
+#[test]
+fn test_pause_without_initialize_returns_uninitialized_admin_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let result = client.try_pause();
+    assert_eq!(result, Err(Ok(Error::from_contract_error(3006))));
 }


### PR DESCRIPTION
## Summary
- replace panic-prone escrow storage reads with explicit contract errors in runtime paths
- preserve current upstream release auth behavior while hardening storage Option handling
- add negative tests for missing escrow entries and uninitialized admin

## Validation
- cargo test -p acbu_escrow

Closes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced hardcoded numeric error codes with named constants for improved error clarity and consistency.
  * Implemented safer initialization patterns to prevent failures when required resources are unavailable.

* **Tests**
  * Added test coverage validating proper error responses for release and refund operations on non-existent escrows.
  * Added test coverage validating error handling when performing operations on uninitialized contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->