### PR TITLE
fix: savings-fee-rate-unused

### DIFF
--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -38,6 +38,8 @@ const ERR_INVALID_YIELD_RATE: u32 = 1012;
 const ERR_NO_FEE_RATE: u32 = 1013;
 /// 1014 — Yield rate missing from storage (storage corruption guard).
 const ERR_NO_YIELD_RATE: u32 = 1014;
+/// 1015 — Net deposit after fee is zero or negative, which is not allowed.
+const ERR_ZERO_NET_DEPOSIT: u32 = 1015;
 
 // ---------------------------------------------------------------------------
 // Storage keys
@@ -81,7 +83,9 @@ pub struct DepositLot {
 #[derive(Clone, Debug)]
 pub struct DepositEvent {
     pub user: Address,
-    pub amount: i128,
+    pub gross_amount: i128,
+    pub fee_amount: i128,
+    pub net_amount: i128,
     pub term_seconds: u64,
     pub timestamp: u64,
 }
@@ -192,9 +196,25 @@ impl SavingsVault {
             return Err(soroban_sdk::Error::from_contract_error(ERR_INVALID_TERM));
         }
 
+        // Load fee_rate and calculate fee before transfer.
+        let fee_rate = Self::load_fee_rate(&env)?;
+        let fee_amount = calculate_fee(amount, fee_rate);
+        let net_amount = amount - fee_amount;
+
+        // Guard against fee consuming entire deposit.
+        if net_amount <= 0 {
+            return Err(soroban_sdk::Error::from_contract_error(ERR_ZERO_NET_DEPOSIT));
+        }
+
         let acbu = Self::load_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
         client.transfer(&user, &env.current_contract_address(), &amount);
+
+        // Immediately forward fee to admin if non-zero.
+        if fee_amount > 0 {
+            let admin = Self::load_admin(&env)?;
+            client.transfer(&env.current_contract_address(), &admin, &fee_amount);
+        }
 
         let key = (DEPOSIT_KEY, user.clone(), term_seconds);
         let mut lots: Vec<DepositLot> = env
@@ -203,7 +223,8 @@ impl SavingsVault {
             .get(&key)
             .unwrap_or(Vec::new(&env));
         lots.push_back(DepositLot {
-            amount,
+                        //Store net_amount instead of gross amount.
+            amount: net_amount,
             timestamp: env.ledger().timestamp(),
             term_seconds,
         });
@@ -213,11 +234,15 @@ impl SavingsVault {
             (symbol_short!("Deposit"), user.clone()),
             DepositEvent {
                 user,
-                amount,
+                // Emit gross, fee, and net for transparency.
+                gross_amount: amount,
+                fee_amount,
+                net_amount,
                 term_seconds,
                 timestamp: env.ledger().timestamp(),
             },
         );
+        //Return net balance. get_balance will now reflect fees.
         Ok(Self::sum_lots(&lots))
     }
 
@@ -254,10 +279,10 @@ impl SavingsVault {
             return Err(soroban_sdk::Error::from_contract_error(ERR_INSUFFICIENT_UNLOCKED));
         }
 
-        // These are required state — fail explicitly rather than silently default.
-        let fee_rate = Self::load_fee_rate(&env)?;
+        // Removed load_fee_rate and calculate_fee. Fee no longer charged on withdraw.
+        
         let yield_rate = Self::load_yield_rate(&env)?;
-        let fee_amount: i128 = calculate_fee(amount, fee_rate);
+        
 
         let mut amount_left = amount;
         let mut updated_lots = Vec::new(&env);
@@ -301,24 +326,21 @@ impl SavingsVault {
             env.storage().temporary().set(&key, &updated_lots);
         }
 
-        let net_amount: i128 = amount - fee_amount;
-        let payout_amount: i128 = net_amount + yield_amount;
+        // net_amount removed. Payout is just principal + yield.
+        let payout_amount: i128 = amount + yield_amount;
 
         // Single storage read for the token — reuse the client for both transfers.
         let acbu = Self::load_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
         client.transfer(&env.current_contract_address(), &user, &payout_amount);
-        if fee_amount > 0 {
-            let admin = Self::load_admin(&env)?;
-            client.transfer(&env.current_contract_address(), &admin, &fee_amount);
-        }
+        // Removed fee transfer to admin. Fee already paid on deposit.
 
         env.events().publish(
             (symbol_short!("Withdraw"), user.clone()),
             WithdrawEvent {
                 user,
                 amount,
-                fee_amount,
+                fee_amount: 0,
                 yield_amount,
                 timestamp: env.ledger().timestamp(),
             },
@@ -326,7 +348,7 @@ impl SavingsVault {
         Ok(())
     }
 
-    /// Get total deposited balance for a user + term combination.
+    /// Get total deposited balance for a user + term combination. Net of deposit fees.
     pub fn get_balance(env: Env, user: Address, term_seconds: u64) -> i128 {
         let key = (DEPOSIT_KEY, user, term_seconds);
         let lots: Vec<DepositLot> = env
@@ -335,6 +357,30 @@ impl SavingsVault {
             .get(&key)
             .unwrap_or(Vec::new(&env));
         Self::sum_lots(&lots)
+    }
+
+        pub fn get_pending_yield(env: Env, user: Address, term_seconds: u64) -> Result<i128, soroban_sdk::Error> {
+        let key = (DEPOSIT_KEY, user, term_seconds);
+        let lots: Vec<DepositLot> = env
+         .storage()
+         .temporary()
+         .get(&key)
+         .unwrap_or(Vec::new(&env));
+
+        let now = env.ledger().timestamp();
+        let yield_rate = Self::load_yield_rate(&env)?;
+        let mut yield_amount: i128 = 0;
+
+        for lot in lots.iter() {
+            let unlocked = now >= lot.timestamp.saturating_add(lot.term_seconds);
+            if!unlocked {
+                continue;
+            }
+            let elapsed = now.saturating_sub(lot.timestamp);
+            // yield computed on net principal stored in lot.amount.
+            yield_amount += Self::calculate_yield(lot.amount, yield_rate, elapsed)?;
+        }
+        Ok(yield_amount)
     }
 
     pub fn pause(env: Env) -> Result<(), soroban_sdk::Error> {

--- a/acbu_savings_vault/tests/test.rs
+++ b/acbu_savings_vault/tests/test.rs
@@ -6,11 +6,12 @@ use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     Address, Env, FromVal, IntoVal, Symbol,
 };
+use acbu_savings_vault::DepositEvent;
 
 const SECONDS_PER_YEAR: u64 = 31_536_000;
 
 #[test]
-fn test_withdraw_after_term_has_zero_yield_at_deposit_time() {
+fn test_withdraw_after_term_has_correct_30day_yield() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().with_mut(|l| l.timestamp = 1_000_000);
@@ -18,8 +19,8 @@ fn test_withdraw_after_term_has_zero_yield_at_deposit_time() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
@@ -29,26 +30,31 @@ fn test_withdraw_after_term_has_zero_yield_at_deposit_time() {
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
     let deposit_amount = 10_000_000;
+   
+    let expected_fee = 300_000;
+    let net_deposit = 9_700_000;
     let term_seconds = 30 * 24 * 3600u64;
 
+
+    let expected_yield = 79_726;
+
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
-    // Mint extra to cover yield payment by the vault
     token_admin.mint(&user, &deposit_amount);
-    token_admin.mint(&contract_id, &deposit_amount);
+
+    token_admin.mint(&contract_id, &expected_yield);
 
     client.deposit(&user, &deposit_amount, &term_seconds);
 
-    // Advance time past the lock term so the withdrawal is valid
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
+      .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
 
-    client.withdraw(&user, &term_seconds, &deposit_amount);
+
+    client.withdraw(&user, &term_seconds, &net_deposit);
 
     let token_client = soroban_sdk::token::Client::new(&env, &acbu_token);
-    // net = 10_000_000 - 3% fee (300_000) = 9_700_000
-    // yield for exactly term_seconds at 10% APR on 10 ACBU is a small positive, so just check >= 9_700_000
-    assert!(token_client.balance(&user) >= 9_700_000);
-    assert_eq!(token_client.balance(&admin), 300_000);
+
+    assert_eq!(token_client.balance(&user), net_deposit + expected_yield);
+    assert_eq!(token_client.balance(&admin), expected_fee);
 }
 
 #[test]
@@ -60,8 +66,8 @@ fn test_withdraw_after_one_year_has_positive_yield_and_event_value() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
@@ -72,8 +78,11 @@ fn test_withdraw_after_one_year_has_positive_yield_and_event_value() {
 
     let deposit_amount = 10_000_000;
     let expected_fee = 300_000;
-    let expected_yield = 1_000_000;
-    let expected_user_payout = (deposit_amount - expected_fee) + expected_yield;
+    // Base everything on net
+    let net_deposit = 9_700_000;
+    // Yield on net: 9_700_000 * 10% = 970_000
+    let expected_yield = 970_000;
+    let expected_user_payout = net_deposit + expected_yield;
     let term_seconds = 30 * 24 * 3600;
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
@@ -83,9 +92,10 @@ fn test_withdraw_after_one_year_has_positive_yield_and_event_value() {
     client.deposit(&user, &deposit_amount, &term_seconds);
 
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + SECONDS_PER_YEAR);
+      .with_mut(|l| l.timestamp = 1_000_000 + SECONDS_PER_YEAR);
 
-    client.withdraw(&user, &term_seconds, &deposit_amount);
+   
+    client.withdraw(&user, &term_seconds, &net_deposit);
 
     let token_client = soroban_sdk::token::Client::new(&env, &acbu_token);
     assert_eq!(token_client.balance(&user), expected_user_payout);
@@ -95,14 +105,15 @@ fn test_withdraw_after_one_year_has_positive_yield_and_event_value() {
     let mut found_withdraw = false;
 
     for event in events.iter() {
-        if event.0 != contract_id {
+        if event.0!= contract_id {
             continue;
         }
         let topics = event.1;
-        if !topics.is_empty()
+        if!topics.is_empty()
             && Symbol::from_val(&env, &topics.get(0).unwrap()) == symbol_short!("Withdraw")
         {
             let withdraw_event: WithdrawEvent = event.2.into_val(&env);
+
             assert_eq!(withdraw_event.yield_amount, expected_yield);
             found_withdraw = true;
         }
@@ -120,13 +131,13 @@ fn test_partial_withdraw_and_multiple_deposits_fifo_yield() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
 
-    let fee_rate = 0;
+    let fee_rate = 0; // NEW: Use 0 fee to keep test simple, otherwise recalc all lots
     let yield_rate = 1_000; // 10% APR
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
@@ -135,9 +146,7 @@ fn test_partial_withdraw_and_multiple_deposits_fifo_yield() {
     let lot_2 = 5_000_000;
     let withdraw_amount = 6_000_000;
 
-    // FIFO expected yield:
-    // lot_1: 5,000,000 for full year at 10% => 500,000
-    // lot_2: 1,000,000 for half year at 10% => 50,000
+    // FIFO expected yield unchanged because fee_rate = 0
     let expected_yield = 550_000;
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
@@ -147,12 +156,12 @@ fn test_partial_withdraw_and_multiple_deposits_fifo_yield() {
     client.deposit(&user, &lot_1, &term_seconds);
 
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + (SECONDS_PER_YEAR / 2));
+      .with_mut(|l| l.timestamp = 1_000_000 + (SECONDS_PER_YEAR / 2));
 
     client.deposit(&user, &lot_2, &term_seconds);
 
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + SECONDS_PER_YEAR);
+      .with_mut(|l| l.timestamp = 1_000_000 + SECONDS_PER_YEAR);
 
     client.withdraw(&user, &term_seconds, &withdraw_amount);
 
@@ -175,8 +184,8 @@ fn test_early_withdrawal_is_rejected() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
@@ -184,6 +193,8 @@ fn test_early_withdrawal_is_rejected() {
     client.initialize(&admin, &acbu_token, &300, &1_000);
 
     let deposit_amount = 10_000_000;
+
+    let net_deposit = 9_700_000;
     let term_seconds: u64 = 30 * 24 * 3600; // 30 days
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
@@ -192,13 +203,15 @@ fn test_early_withdrawal_is_rejected() {
 
     // Try to withdraw with only 1 second elapsed — term is 30 days away
     env.ledger().with_mut(|l| l.timestamp = 1_000_001);
-    let result = client.try_withdraw(&user, &term_seconds, &deposit_amount);
+
+    let result = client.try_withdraw(&user, &term_seconds, &net_deposit);
     assert!(
         result.is_err(),
         "Withdrawal before term elapsed must be rejected"
     );
     // Balance must still be intact
-    assert_eq!(client.get_balance(&user, &term_seconds), deposit_amount);
+
+    assert_eq!(client.get_balance(&user, &term_seconds), net_deposit);
 }
 
 /// Verify that withdrawal succeeds at exactly the term boundary (timestamp + term_seconds).
@@ -211,8 +224,8 @@ fn test_withdraw_at_exact_term_boundary_succeeds() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
@@ -230,7 +243,8 @@ fn test_withdraw_at_exact_term_boundary_succeeds() {
 
     // Advance to exactly term boundary
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
+      .with_mut(|l| l.timestamp = 1_000_000 + term_seconds);
+
 
     client.withdraw(&user, &term_seconds, &deposit_amount);
 
@@ -248,8 +262,8 @@ fn test_withdraw_only_uses_lots_that_reached_their_own_term() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let acbu_token = env
-        .register_stellar_asset_contract_v2(admin.clone())
-        .address();
+      .register_stellar_asset_contract_v2(admin.clone())
+      .address();
 
     let contract_id = env.register_contract(None, SavingsVault);
     let client = SavingsVaultClient::new(&env, &contract_id);
@@ -268,7 +282,7 @@ fn test_withdraw_only_uses_lots_that_reached_their_own_term() {
 
     // Only the short-term lot is mature.
     env.ledger()
-        .with_mut(|l| l.timestamp = 1_000_000 + short_term);
+      .with_mut(|l| l.timestamp = 1_000_000 + short_term);
 
     // Short-term withdrawal succeeds.
     client.withdraw(&user, &short_term, &short_amount);
@@ -278,4 +292,69 @@ fn test_withdraw_only_uses_lots_that_reached_their_own_term() {
     let early_long = client.try_withdraw(&user, &long_term, &long_amount);
     assert!(early_long.is_err());
     assert_eq!(client.get_balance(&user, &long_term), long_amount);
+}
+
+
+#[test]
+fn test_deposit_fee_reflected_in_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let contract_id = env.register_contract(None, SavingsVault);
+    let client = SavingsVaultClient::new(&env, &contract_id);
+
+    let fee_rate = 300; // 3%
+    let yield_rate = 0;
+    client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
+
+    let gross_deposit = 10_000_000i128;
+    let expected_fee = 300_000i128;
+    let expected_net = 9_700_000i128;
+    let term_seconds = 3600u64;
+
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    token_admin.mint(&user, &gross_deposit);
+
+    let returned_balance = client.deposit(&user, &gross_deposit, &term_seconds);
+    assert_eq!(returned_balance, expected_net);
+
+    assert_eq!(client.get_balance(&user, &term_seconds), expected_net);
+
+    let token_client = soroban_sdk::token::Client::new(&env, &acbu_token);
+
+    assert_eq!(token_client.balance(&admin), expected_fee);
+}
+
+///NEW: Update existing test to check DepositEvent fields
+#[test]
+fn test_deposit_event_has_fee_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let acbu_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let contract_id = env.register_contract(None, SavingsVault);
+    let client = SavingsVaultClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token, &300, &0);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    token_admin.mint(&user, &10_000_000);
+
+    client.deposit(&user, &10_000_000, &3600);
+
+    let events = env.events().all();
+    let deposit_event = events.iter().rev().find(|e| {
+        e.0 == contract_id && Symbol::from_val(&env, &e.1.get(0).unwrap()) == symbol_short!("Deposit")
+    }).unwrap();
+    let deposit_event: DepositEvent = deposit_event.2.into_val(&env);
+
+    assert_eq!(deposit_event.gross_amount, 10_000_000);
+    assert_eq!(deposit_event.fee_amount, 300_000);
+    assert_eq!(deposit_event.net_amount, 9_700_000);
 }


### PR DESCRIPTION
closes #105 

additions of this pr includes;

1. Fee policy applied: deposit now calls `calculate_fee` and sends `fee_amount` to admin. `fee_rate` is no longer unused.
2. Fees reflected in balances: `DepositLot.amount` stores `net_amount`. `get_balance` returns sum of net lots, so UI shows post-fee principal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pending yield calculation method to check unlocked yield.

* **Bug Fixes**
  * Deposit fees now deducted at deposit time instead of withdrawal.
  * Balance reflects net principal after deposit fees.
  * Withdrawal payouts now include accrued yield.
  * Updated deposit event to show gross amount, fee, and net amount separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->