### PR TITLE
fix: commit Cargo.lock and enforce --locked builds in CI

### DIFF
--- a/.github/workflows/verify-wasm-integrity.yml
+++ b/.github/workflows/verify-wasm-integrity.yml
@@ -9,6 +9,7 @@ on:
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
       - 'Cargo.lock'
+      - '**/Cargo.toml'
       - '.github/workflows/verify-wasm-integrity.yml'
   pull_request:
     branches: [ main, develop ]
@@ -18,6 +19,7 @@ on:
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
       - 'Cargo.lock'
+      - '**/Cargo.toml'
 
 jobs:
   verify-wasm-hash:
@@ -145,3 +147,58 @@ jobs:
           name: wasm-artifacts
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Reproducible-build gate: ensures Cargo.lock is committed and up-to-date.
+  # `--locked` fails if the lockfile is absent or if any dependency would
+  # change, guaranteeing every CI build resolves the exact same dep tree.
+  # ---------------------------------------------------------------------------
+  locked-build:
+    name: Verify Locked Build (Reproducibility)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Restore cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-locked-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-locked-
+
+      - name: Verify Cargo.lock is committed
+        run: |
+          if [ ! -f Cargo.lock ]; then
+            echo "❌ FAIL: Cargo.lock is not committed."
+            echo "Run 'cargo generate-lockfile' and commit the result."
+            exit 1
+          fi
+          echo "✅ Cargo.lock present"
+
+      - name: Build with --locked (native, all workspace crates)
+        run: cargo build --locked --workspace
+
+      - name: Build with --locked (wasm32 release, all workspace crates)
+        run: cargo build --locked --workspace --target wasm32-unknown-unknown --release
+
+      - name: Verify lockfile is not stale
+        run: |
+          # If Cargo.lock would change after a fresh resolve, the committed
+          # lockfile is out of sync with Cargo.toml — fail loudly.
+          cargo update --workspace --locked 2>&1 | tee /tmp/update_output.txt
+          if grep -q "Updating" /tmp/update_output.txt; then
+            echo "❌ FAIL: Cargo.lock is stale — run 'cargo update' and commit."
+            cat /tmp/update_output.txt
+            exit 1
+          fi
+          echo "✅ Cargo.lock is up-to-date"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Build artifacts
 /target/
 
-# Cargo lock (for libraries; keep for application crates if preferred)
-Cargo.lock
-
 # Editor/IDE files
 .idea/
 .vscode/
@@ -19,7 +16,6 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 target/
-Cargo.lock
 **/*.rs.bk
 .soroban/
 .stellar/


### PR DESCRIPTION
Closes #124

Cargo.lock was gitignored, meaning every cargo build resolved dependencies fresh. Two developers (or two CI runs) could silently pull different crate versions, making builds non-reproducible and opening a supply chain risk window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI pipeline with stricter dependency reproducibility checks.
  * Enabled dependency lock file tracking in version control for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->