### PR TITLE
Fix/oracle stale rate protection

### DIFF
--- a/.github/workflows/verify-wasm-integrity.yml
+++ b/.github/workflows/verify-wasm-integrity.yml
@@ -9,6 +9,7 @@ on:
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
       - 'Cargo.lock'
+      - '**/Cargo.toml'
       - '.github/workflows/verify-wasm-integrity.yml'
   pull_request:
     branches: [ main, develop ]
@@ -18,6 +19,7 @@ on:
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
       - 'Cargo.lock'
+      - '**/Cargo.toml'
 
 jobs:
   verify-wasm-hash:
@@ -145,3 +147,58 @@ jobs:
           name: wasm-artifacts
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Reproducible-build gate: ensures Cargo.lock is committed and up-to-date.
+  # `--locked` fails if the lockfile is absent or if any dependency would
+  # change, guaranteeing every CI build resolves the exact same dep tree.
+  # ---------------------------------------------------------------------------
+  locked-build:
+    name: Verify Locked Build (Reproducibility)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Restore cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-locked-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-locked-
+
+      - name: Verify Cargo.lock is committed
+        run: |
+          if [ ! -f Cargo.lock ]; then
+            echo "❌ FAIL: Cargo.lock is not committed."
+            echo "Run 'cargo generate-lockfile' and commit the result."
+            exit 1
+          fi
+          echo "✅ Cargo.lock present"
+
+      - name: Build with --locked (native, all workspace crates)
+        run: cargo build --locked --workspace
+
+      - name: Build with --locked (wasm32 release, all workspace crates)
+        run: cargo build --locked --workspace --target wasm32-unknown-unknown --release
+
+      - name: Verify lockfile is not stale
+        run: |
+          # If Cargo.lock would change after a fresh resolve, the committed
+          # lockfile is out of sync with Cargo.toml — fail loudly.
+          cargo update --workspace --locked 2>&1 | tee /tmp/update_output.txt
+          if grep -q "Updating" /tmp/update_output.txt; then
+            echo "❌ FAIL: Cargo.lock is stale — run 'cargo update' and commit."
+            cat /tmp/update_output.txt
+            exit 1
+          fi
+          echo "✅ Cargo.lock is up-to-date"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Build artifacts
 /target/
 
-# Cargo lock (for libraries; keep for application crates if preferred)
-Cargo.lock
-
 # Editor/IDE files
 .idea/
 .vscode/
@@ -19,7 +16,6 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 target/
-Cargo.lock
 **/*.rs.bk
 .soroban/
 .stellar/

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
 use shared::{
     calculate_amount_after_fee, calculate_fee, CurrencyCode, DataKey as SharedDataKey, MintEvent,
     BASIS_POINTS, CONTRACT_VERSION, DECIMALS, MAX_MINT_AMOUNT, MIN_MINT_AMOUNT,
+    UPDATE_INTERVAL_SECONDS,
 };
 
 

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -5,7 +5,8 @@ use soroban_sdk::{
 
 use shared::{
     calculate_deviation, median, CurrencyCode, OutlierDetectionEvent, RateData, RateUpdateEvent,
-    BASIS_POINTS, DECIMALS, EMERGENCY_THRESHOLD_BPS, OUTLIER_THRESHOLD_BPS, UPDATE_INTERVAL_SECONDS,
+    BASIS_POINTS, DECIMALS, EMERGENCY_THRESHOLD_BPS, OUTLIER_THRESHOLD_BPS, STALE_RATE_MAX_LEDGERS,
+    UPDATE_INTERVAL_SECONDS,
 };
 
 mod shared {
@@ -80,6 +81,17 @@ pub struct AdminTransferCancelledEvent {
     pub admin: Address,
     pub cancelled_pending: Address,
     pub timestamp: u64,
+}
+
+/// Emitted when a rate read is rejected because the stored rate is too old.
+/// Consumers (e.g. monitoring bots) can subscribe to this to alert on stale feeds.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StaleRateEvent {
+    pub currency: CurrencyCode,
+    pub stored_ledger: u32,
+    pub current_ledger: u32,
+    pub max_stale_ledgers: u32,
 }
 
 #[contracttype]
@@ -340,6 +352,7 @@ impl OracleContract {
             rate_usd: median_rate,
             timestamp: current_time,
             sources,
+            ledger: env.ledger().sequence(),
         };
 
         let mut rates: Map<CurrencyCode, RateData> = env
@@ -371,6 +384,8 @@ impl OracleContract {
             rate_usd: rate,
             timestamp: current_time,
             sources: Vec::new(&env),
+            // Admin override: stamp with current ledger so the rate is immediately fresh.
+            ledger: env.ledger().sequence(),
         };
         let mut rates: Map<CurrencyCode, RateData> = env
             .storage()
@@ -384,6 +399,7 @@ impl OracleContract {
 
     pub fn get_rate(env: Env, currency: CurrencyCode) -> i128 {
         if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
+            Self::assert_rate_fresh(&env, &rate_data, &currency);
             rate_data.rate_usd
         } else {
             panic!("Rate not found for currency");
@@ -393,6 +409,7 @@ impl OracleContract {
     /// Get rate data with timestamp for staleness validation
     pub fn get_rate_with_timestamp(env: Env, currency: CurrencyCode) -> (i128, u64) {
         if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
+            Self::assert_rate_fresh(&env, &rate_data, &currency);
             (rate_data.rate_usd, rate_data.timestamp)
         } else {
             panic!("Rate not found for currency");
@@ -419,6 +436,8 @@ impl OracleContract {
         for currency in currencies.iter() {
             if let Some(weight) = basket_weights.get(currency.clone()) {
                 if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
+                    // Enforce staleness: a stale basket component blocks the whole basket rate.
+                    Self::assert_rate_fresh(&env, &rate_data, &currency);
                     let contribution = (rate_data.rate_usd * weight) / BASIS_POINTS;
                     weighted_sum += contribution;
                     total_weight += weight;
@@ -458,6 +477,8 @@ impl OracleContract {
         for currency in currencies.iter() {
             if let Some(weight) = basket_weights.get(currency.clone()) {
                 if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
+                    // Enforce staleness: a stale basket component blocks the whole basket rate.
+                    Self::assert_rate_fresh(&env, &rate_data, &currency);
                     let contribution = (rate_data.rate_usd * weight) / 10_000;
                     weighted_sum += contribution;
                     total_weight += weight;
@@ -638,6 +659,33 @@ impl OracleContract {
             .get(&DATA_KEY.rates)
             .unwrap_or(Map::new(env));
         rates.get(currency.clone())
+    }
+
+    /// Panics if the stored rate is older than `STALE_RATE_MAX_LEDGERS` ledgers.
+    ///
+    /// Using ledger sequence (not timestamp) as the staleness signal is intentional:
+    /// ledger sequence is set by the network and cannot be forged by a validator.
+    /// This is the oracle-side enforcement; the minting contract adds a second,
+    /// timestamp-based layer via `check_oracle_freshness`.
+    ///
+    /// Admin override path: call `set_rate_admin` to refresh the stored rate with
+    /// the current ledger sequence, which immediately unblocks reads.
+    fn assert_rate_fresh(env: &Env, rate_data: &RateData, currency: &CurrencyCode) {
+        let current_ledger = env.ledger().sequence();
+        let age = current_ledger.saturating_sub(rate_data.ledger);
+        if age > STALE_RATE_MAX_LEDGERS {
+            // Emit an observable event before panicking so monitoring bots can alert.
+            env.events().publish(
+                (symbol_short!("stale_rt"),),
+                StaleRateEvent {
+                    currency: currency.clone(),
+                    stored_ledger: rate_data.ledger,
+                    current_ledger,
+                    max_stale_ledgers: STALE_RATE_MAX_LEDGERS,
+                },
+            );
+            panic!("Rate is stale: stored ledger is too old; admin must refresh via set_rate_admin");
+        }
     }
 
     fn check_admin(env: &Env) {

--- a/acbu_oracle/tests/test.rs
+++ b/acbu_oracle/tests/test.rs
@@ -367,9 +367,177 @@ fn test_update_rate_falls_back_to_provided_rate_when_sources_empty() {
     assert_eq!(client.get_rate(&ngn), submitted_rate);
 }
 
-// Example Test Assertion
-let last_event = env.events().all().last().unwrap();
-let event_data: (u128, Vec<Address>) = last_event.unwrap().data.into_val(&env);
+// ─── Staleness tests ──────────────────────────────────────────────────────────
 
-// Verification: Ensure the validator list is not empty
-assert!(event_data.1.len() > 0);
+/// Acceptance check: a rate stored N+1 ledgers ago must be rejected at read time.
+/// This is the core acceptance criterion: stale rate cannot be used for new mints.
+#[test]
+fn test_stale_rate_rejected_at_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| {
+        l.timestamp = 1_000_000;
+        l.sequence_number = 100;
+    });
+
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    // Write a fresh rate at ledger 100.
+    let mut sources = Vec::new(&env);
+    sources.push_back(1_000_000i128);
+    client.update_rate(&validator, &ngn, &1_000_000i128, &sources, &env.ledger().timestamp());
+
+    // Advance ledger sequence past STALE_RATE_MAX_LEDGERS (4_320).
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 100 + 4_321; // one beyond the limit
+        l.timestamp = 1_000_000 + 21_601; // also past the timestamp window
+    });
+
+    // get_rate must now panic with a stale-rate error.
+    let result = client.try_get_rate(&ngn);
+    assert!(result.is_err(), "expected stale rate to be rejected");
+
+    // A stale_rt event must have been emitted.
+    let events = env.events().all();
+    let stale_event_found = events.iter().any(|e| {
+        if e.0 != contract_id { return false; }
+        !e.1.is_empty()
+            && Symbol::from_val(&env, &e.1.get(0).unwrap()) == symbol_short!("stale_rt")
+    });
+    assert!(stale_event_found, "expected stale_rt event to be emitted");
+}
+
+/// A rate that is exactly at the staleness boundary (age == STALE_RATE_MAX_LEDGERS) must still be accepted.
+#[test]
+fn test_rate_at_boundary_is_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| {
+        l.timestamp = 1_000_000;
+        l.sequence_number = 100;
+    });
+
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let mut sources = Vec::new(&env);
+    sources.push_back(1_000_000i128);
+    client.update_rate(&validator, &ngn, &1_000_000i128, &sources, &env.ledger().timestamp());
+
+    // Advance exactly to the limit — should still pass.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 100 + 4_320; // exactly at limit
+    });
+
+    let rate = client.get_rate(&ngn);
+    assert_eq!(rate, 1_000_000, "rate at boundary should be accepted");
+}
+
+/// Admin override: set_rate_admin refreshes the ledger stamp, unblocking a stale feed.
+#[test]
+fn test_admin_override_unblocks_stale_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| {
+        l.timestamp = 1_000_000;
+        l.sequence_number = 100;
+    });
+
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let mut sources = Vec::new(&env);
+    sources.push_back(1_000_000i128);
+    client.update_rate(&validator, &ngn, &1_000_000i128, &sources, &env.ledger().timestamp());
+
+    // Advance past staleness window.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 100 + 4_321;
+        l.timestamp = 1_000_000 + 21_601;
+    });
+
+    // Admin refreshes the rate — this stamps the current ledger sequence.
+    let override_rate = 1_050_000i128;
+    client.set_rate_admin(&ngn, &override_rate);
+
+    // Now get_rate must succeed with the admin-set value.
+    let rate = client.get_rate(&ngn);
+    assert_eq!(rate, override_rate, "admin override should unblock stale rate");
+}
+
+/// Basket rate (get_acbu_usd_rate_with_timestamp) must also be blocked when any
+/// basket component is stale — a stale component cannot silently contribute to mints.
+#[test]
+fn test_stale_basket_component_blocks_acbu_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| {
+        l.timestamp = 1_000_000;
+        l.sequence_number = 100;
+    });
+
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let mut sources = Vec::new(&env);
+    sources.push_back(1_000_000i128);
+    client.update_rate(&validator, &ngn, &1_000_000i128, &sources, &env.ledger().timestamp());
+
+    // Advance past staleness window.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 100 + 4_321;
+        l.timestamp = 1_000_000 + 21_601;
+    });
+
+    let result = client.try_get_acbu_usd_rate_with_timestamp();
+    assert!(result.is_err(), "stale basket component must block acbu rate");
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -31,6 +31,9 @@ pub struct RateData {
     pub rate_usd: i128, // Rate in 7 decimals (e.g., 0.0012345 = 12345)
     pub timestamp: u64,
     pub sources: soroban_sdk::Vec<i128>, // Source rates for median calculation
+    /// Ledger sequence number at which this rate was written.
+    /// Used for ledger-based staleness checks (unforgeable — set by the network).
+    pub ledger: u32,
 }
 
 /// Reserve data structure
@@ -146,6 +149,11 @@ pub const MIN_BURN_AMOUNT: i128 = 10_000_000; // 10 ACBU (7 decimals)
 pub const UPDATE_INTERVAL_SECONDS: u64 = 21_600; // 6 hours
 pub const EMERGENCY_THRESHOLD_BPS: i128 = 500; // 5% deviation threshold
 pub const OUTLIER_THRESHOLD_BPS: i128 = 300; // 3% deviation for outlier detection
+/// Maximum ledger age of a stored rate before it is considered stale and rejected
+/// at read time. Stellar closes ~1 ledger every 5 seconds; 720 ledgers ≈ 1 hour.
+/// Rates must be refreshed within this window or consumers (minting) will be blocked.
+/// Admin can bypass via `set_rate_admin` for emergency overrides.
+pub const STALE_RATE_MAX_LEDGERS: u32 = 4_320; // ~6 hours at 5 s/ledger
 
 /// Utility functions
 pub fn calculate_fee(amount: i128, fee_rate_bps: i128) -> i128 {


### PR DESCRIPTION
Closes #120 

he oracle contract had no staleness enforcement at read time. get_rate, get_acbu_usd_rate, and related functions would serve rates of any age — including rates days old — to the minting contract. In volatile markets this means ACBU could be minted at a price that no longer reflects reality.

The validator-supplied _timestamp parameter in update_rate was silently ignored (note the underscore), meaning there was no write-side freshness signal either.