### PR TITLE
ci: add automated contract size budget check (Issue #123)

### DIFF
--- a/.github/workflows/verify-wasm-integrity.yml
+++ b/.github/workflows/verify-wasm-integrity.yml
@@ -8,6 +8,7 @@ on:
       - 'acbu_minting/src/lib.rs'
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
+      - 'scripts/check_budget.sh'
       - 'Cargo.lock'
       - '.github/workflows/verify-wasm-integrity.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'acbu_minting/src/lib.rs'
       - 'acbu_burning/src/lib.rs'
       - 'acbu_reserve_tracker/src/lib.rs'
+      - 'scripts/check_budget.sh'
       - 'Cargo.lock'
 
 jobs:

--- a/.github/workflows/verify-wasm-integrity.yml
+++ b/.github/workflows/verify-wasm-integrity.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Build contracts
         run: cargo build --target wasm32-unknown-unknown --release
 
+      - name: Check Contract Budget
+        run: ./scripts/check_budget.sh
+
       - name: Verify build artifacts
         run: |
           echo "Verifying build artifacts..."

--- a/scripts/check_budget.sh
+++ b/scripts/check_budget.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_SIZE_BYTES=60000
+WASM_DIR="target/wasm32-unknown-unknown/release"
+
+if [[ ! -d "$WASM_DIR" ]]; then
+	echo "Error: WASM directory not found: $WASM_DIR" >&2
+	exit 1
+fi
+
+shopt -s nullglob
+wasm_files=("$WASM_DIR"/*.wasm)
+
+if (( ${#wasm_files[@]} == 0 )); then
+	echo "Error: no .wasm files found in $WASM_DIR" >&2
+	exit 1
+fi
+
+has_violation=0
+
+for wasm_file in "${wasm_files[@]}"; do
+	size_bytes=$(stat -c '%s' "$wasm_file")
+	contract_name=$(basename "$wasm_file")
+
+	echo "$contract_name: $size_bytes bytes"
+
+	if (( size_bytes > MAX_SIZE_BYTES )); then
+		echo "Error: $contract_name exceeds the maximum size of $MAX_SIZE_BYTES bytes" >&2
+		has_violation=1
+	fi
+done
+
+if (( has_violation )); then
+	exit 1
+fi
+
+echo "Success: all WASM contracts are within the $MAX_SIZE_BYTES byte limit."


### PR DESCRIPTION
This pull request adds an automated check to ensure that all compiled WASM contract files do not exceed a specified size limit during the CI build process. The main change introduces a script that verifies the size of each contract and fails the build if any contract is too large.

**CI Workflow Improvements:**

* Added a new step in the `.github/workflows/verify-wasm-integrity.yml` workflow to run a contract budget check after building contracts.

**New Script for WASM Size Enforcement:**

* Introduced `scripts/check_budget.sh`, a Bash script that checks all `.wasm` files in the release directory to ensure they do not exceed 60,000 bytes, and fails the build with an error message if any do.

Closes #123 