### PR TITLE
fix: apply CEI ordering to escrow and savings vault token callbacks (C-036)

### DIFF
--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -119,11 +119,15 @@ impl Escrow {
 
         let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
-        client.transfer(&payer, &env.current_contract_address(), &amount);
 
+        // CEI: write state before the external token transfer so any token-level
+        // callback observes the escrow as already recorded.
         env.storage()
             .temporary()
             .set(&key, &(payer.clone(), payee.clone(), amount));
+
+        client.transfer(&payer, &env.current_contract_address(), &amount);
+
         env.events().publish(
             (symbol_short!("esc_crtd"), escrow_id),
             EscrowCreatedEvent {
@@ -166,9 +170,13 @@ impl Escrow {
 
         let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
+
+        // CEI: remove the escrow record before the external transfer so the
+        // escrow cannot be claimed a second time if the token executes a callback.
+        env.storage().temporary().remove(&key);
+
         client.transfer(&env.current_contract_address(), &payee, &amount);
 
-        env.storage().temporary().remove(&key);
         env.events().publish(
             (symbol_short!("esc_rel"), escrow_id),
             EscrowReleasedEvent {
@@ -203,9 +211,13 @@ impl Escrow {
 
         let acbu = Self::get_acbu_token(&env)?;
         let client = soroban_sdk::token::Client::new(&env, &acbu);
+
+        // CEI: remove the escrow record before the external transfer so the
+        // escrow cannot be refunded twice if the token executes a callback.
+        env.storage().temporary().remove(&key);
+
         client.transfer(&env.current_contract_address(), &payer, &amount);
 
-        env.storage().temporary().remove(&key);
         env.events().publish(
             (symbol_short!("esc_ref"), escrow_id),
             EscrowRefundedEvent {

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -204,12 +204,8 @@ impl SavingsVault {
         let token = soroban_sdk::token::Client::new(&env, &acbu);
         let vault_addr = env.current_contract_address();
 
-        // Transfer the net amount to the vault and the fee to the admin
-        token.transfer(&user, &vault_addr, &net_amount);
-        if fee_amount > 0 {
-            token.transfer(&user, &admin, &fee_amount);
-        }
-
+        // CEI: record the deposit lot before the external token transfers so any
+        // token-level callback sees the new deposit as already committed.
         let key = (DEPOSIT_KEY, user.clone(), term_seconds);
         let mut lots: Vec<DepositLot> = env
             .storage()
@@ -224,6 +220,12 @@ impl SavingsVault {
         });
 
         env.storage().temporary().set(&key, &lots);
+
+        // Transfer the net amount to the vault and the fee to the admin.
+        token.transfer(&user, &vault_addr, &net_amount);
+        if fee_amount > 0 {
+            token.transfer(&user, &admin, &fee_amount);
+        }
 
         env.events().publish(
             (symbol_short!("Deposit"), user.clone()),

--- a/docs/reentrancy-audit-c036.md
+++ b/docs/reentrancy-audit-c036.md
@@ -1,0 +1,192 @@
+# C-036 — Reentrancy Class Issues via Token Callbacks: Audit Notes
+
+**Issue:** C-036  
+**Severity:** Medium  
+**Area:** contracts/security  
+**Auditor:** sanmipaul  
+
+---
+
+## Background: Reentrancy in Soroban
+
+Classic EVM reentrancy (recursive `call` while executing) does not apply to Soroban.
+The Soroban host enforces a call stack that prevents a contract from being re-entered
+while it is already on the stack.
+
+However, a weaker class of attack is still relevant: **token-callback state confusion**.
+If a token contract (ACBU or an S-token) executes logic during `transfer` or
+`transfer_from` that reads or writes to the *calling* contract's storage, it may
+observe stale state when the calling contract has not yet committed its effects.
+The standard defense is **Checks-Effects-Interactions (CEI)** ordering:
+
+1. **Checks** — validate all preconditions
+2. **Effects** — commit all state changes to storage
+3. **Interactions** — make external calls (token transfers, cross-contract invocations)
+
+All contracts in this repository use the standard Soroban `token::Client` which
+reflects the SEP-41 interface. As of the current version, the SEP-41 token interface
+does not define a receiver callback hook (no `on_transfer` equivalent). This means
+that in practice, the immediate reentrancy risk through the current ACBU and S-token
+contracts is low. Nevertheless, CEI ordering is applied throughout as a defensive
+measure and to ensure the codebase remains correct if the token interface evolves.
+
+---
+
+## Contract-by-Contract Findings
+
+### 1. `acbu_burning` — `redeem_single` ✅ Sound
+
+**Order (before fix):**
+```
+1. Checks: pause, min amount, oracle freshness, reserve check (invoke_contract × 3)
+2. Interactions: acbu_client.burn(&user, &acbu_amount)
+3. Interactions: token.transfer_from(&spender, &vault, &recipient, &stoken_out)
+4. Events
+```
+
+**Assessment:** The burning contract holds no mutable per-user accounting state.
+The ACBU burn reduces token supply before the s-token payout, which is the correct
+sequence. Reserve check reads supply *before* the burn (conservative — worst case
+supply), which is safe. No CEI fix required.
+
+---
+
+### 2. `acbu_burning` — `redeem_basket` ⚠️ Noted — Partial-Failure Risk
+
+**Order:**
+```
+1. Checks: oracle freshness, reserve check
+2. Interactions: acbu_client.burn(&user, &acbu_amount)    ← ACBU irrevocably burned
+3. Loop: for each currency:
+       invoke_contract (oracle reads)
+       token.transfer_from(&spender, &vault, &recipient, &native_i)   ← per-currency payout
+```
+
+**Assessment:** Not a reentrancy issue (no local state to corrupt), but there is a
+**partial-execution risk**: if any `transfer_from` in the loop panics (e.g., vault
+has insufficient balance for one currency), the user's ACBU has already been burned
+but they receive only some of their s-tokens. This is an atomic-batch concern, not a
+reentrancy concern. Tracked separately from C-036; noted here for completeness.
+
+No CEI fix applied to this function.
+
+---
+
+### 3. `acbu_savings_vault` — `deposit` ✅ Fixed (CEI violation)
+
+**Order before fix:**
+```
+1. Checks: pause, amount > 0, term > 0
+2. Interactions: token.transfer(&user, &vault_addr, &net_amount)    ← external call
+3. Interactions: token.transfer(&user, &admin, &fee_amount)          ← external call
+4. Effects:   env.storage().temporary().set(&key, &lots)              ← state AFTER transfers ❌
+```
+
+**Violation:** A token contract with a receiver hook executing during `transfer`
+could call back into `deposit` for the same `(user, term_seconds)` key and observe
+an empty lot list, allowing a second deposit to overwrite the first lot once the
+original call resumes.
+
+**Fix applied:** Deposit lot is written to storage **before** both `transfer` calls.
+
+**Order after fix:**
+```
+1. Checks
+2. Effects:  env.storage().temporary().set(&key, &lots)   ← state first ✅
+3. Interactions: token.transfer (vault) + token.transfer (admin fee)
+```
+
+---
+
+### 4. `acbu_savings_vault` — `withdraw` ✅ Sound
+
+**Order:**
+```
+1. Checks
+2. Effects: env.storage().temporary().set or .remove     ← state cleared first ✅
+3. Interactions: token.transfer (principal) + token.transfer (yield)
+```
+
+**Assessment:** Already CEI-correct. State is cleared before any outbound transfers.
+
+---
+
+### 5. `acbu_lending_pool` — `deposit` / `withdraw` ⚠️ No Per-Lender State
+
+**Assessment:** The lending pool does not maintain per-lender balance accounting.
+`deposit` emits an event but writes no balance to storage. `withdraw` performs no
+balance check — any authorised address can withdraw any amount up to the contract's
+total token balance.
+
+This is a functional incompleteness issue (tracked separately), not a reentrancy
+issue. CEI cannot be violated where no state transitions exist. Noted here because
+the absence of state updates is itself a security gap.
+
+---
+
+### 6. `acbu_escrow` — `create` ✅ Fixed (CEI violation)
+
+**Order before fix:**
+```
+1. Checks: pause, amount > 0, escrow_id not already in use
+2. Interactions: client.transfer(&payer, &contract, &amount)          ← external call ❌
+3. Effects:   env.storage().temporary().set(&key, &(payer, payee, amount))
+```
+
+**Violation:** A token callback during the inbound `transfer` could call `create`
+again with the same `escrow_id`. At that point `env.storage().temporary().has(&key)`
+still returns `false`, so the duplicate-key guard passes and the escrow is written
+with new parameters. When the original call resumes it overwrites the re-entrant
+write, potentially with different `payee` or `amount` values.
+
+**Fix applied:** `env.storage().temporary().set(...)` moved to **before** the
+`client.transfer(...)` call.
+
+---
+
+### 7. `acbu_escrow` — `release` ✅ Fixed (CEI violation)
+
+**Order before fix:**
+```
+1. Checks: pause, payer auth, escrow exists, payer matches
+2. Interactions: client.transfer(&contract, &payee, &amount)   ← external call ❌
+3. Effects:   env.storage().temporary().remove(&key)
+```
+
+**Violation:** A token callback during the outbound `transfer` could call `release`
+again. At that point the escrow record is still in storage, so all checks pass and
+the payee receives a second payout.
+
+**Fix applied:** `env.storage().temporary().remove(&key)` moved to **before** the
+`client.transfer(...)` call.
+
+---
+
+### 8. `acbu_escrow` — `refund` ✅ Fixed (CEI violation)
+
+**Same violation and fix as `release`.** `env.storage().temporary().remove(&key)`
+moved to before the `client.transfer(...)` call so the escrow cannot be double-refunded.
+
+---
+
+## Summary Table
+
+| Contract | Function | Status | Finding |
+|---|---|---|---|
+| `acbu_burning` | `redeem_single` | ✅ Sound | CEI satisfied; no fix needed |
+| `acbu_burning` | `redeem_basket` | ⚠️ Noted | Partial-execution risk (not reentrancy); separate issue |
+| `acbu_savings_vault` | `deposit` | ✅ Fixed | Storage update moved before token transfers |
+| `acbu_savings_vault` | `withdraw` | ✅ Sound | CEI already satisfied |
+| `acbu_lending_pool` | `deposit` | ⚠️ Noted | No per-lender state; functional gap, not reentrancy |
+| `acbu_lending_pool` | `withdraw` | ⚠️ Noted | No balance check; functional gap, not reentrancy |
+| `acbu_escrow` | `create` | ✅ Fixed | State written before inbound transfer |
+| `acbu_escrow` | `release` | ✅ Fixed | State cleared before outbound transfer |
+| `acbu_escrow` | `refund` | ✅ Fixed | State cleared before outbound transfer |
+
+## Acceptance Checklist
+
+- [x] All token-callback CEI violations identified
+- [x] All violations fixed with before/after ordering documented
+- [x] Non-reentrancy findings (partial-execution, missing state) noted for separate tracking
+- [x] Soroban reentrancy model documented (no `on_transfer` hook in SEP-41; host blocks recursive re-entry)
+- [ ] External reviewer sign-off


### PR DESCRIPTION
## Summary

Resolves **C-036 — Reentrancy class issues via token callbacks**.

- Applied Checks-Effects-Interactions (CEI) ordering to 4 functions across 2 contracts where state updates occurred **after** external token transfers
- Added `docs/reentrancy-audit-c036.md` with per-function findings for external reviewer sign-off

## Soroban Reentrancy Context

Soroban's host blocks recursive re-entry by default, so classic EVM-style reentrancy is not possible. However, the SEP-41 token interface may evolve to include receiver hooks, and CEI-correct ordering is the safe baseline. The audit document explains the model in detail.

## Changes

### `acbu_escrow/src/lib.rs` — 3 fixes

**`create`**: escrow record written to storage **before** the inbound `token.transfer`. Previously, a token callback could call `create` again with the same `escrow_id`, pass the duplicate-key guard (record not yet written), and overwrite the escrow entry.

**`release`**: escrow record removed **before** the outbound `token.transfer`. Previously, a callback could re-enter `release`, find the escrow still in storage, and trigger a double payout.

**`refund`**: same fix as `release` — escrow cleared before transfer to prevent double-refund.

### `acbu_savings_vault/src/lib.rs` — 1 fix

**`deposit`**: deposit lot committed to temporary storage **before** both `token.transfer` calls. Previously, a token callback could re-enter `deposit` for the same `(user, term_seconds)` key, see an empty lot list, and have its write overwritten when the original call resumed.

`withdraw` was already CEI-correct (state cleared before outbound transfers) — no changes needed.

### `docs/reentrancy-audit-c036.md` — new file

Full audit notes covering:
- Soroban reentrancy model explanation
- Per-function CEI analysis for all 5 contracts
- Before/after ordering for each fix
- Summary table
- Acceptance checklist for external reviewer

## Test plan

- [ ] Existing escrow tests pass (`cargo test -p acbu_escrow`)
- [ ] Existing savings vault tests pass (`cargo test -p acbu_savings_vault`)
- [ ] Audit doc reviewed and signed off by external reviewer

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted execution flow in escrow and savings vault operations to improve transaction safety and prevent potential state inconsistencies during external token transfers.

* **Documentation**
  * Added comprehensive audit documentation analyzing security considerations and contract function behavior, including findings and recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->