### PR TITLE
Centralize DECIMALS usage; replace literals and add rounding integrat…

### DIFF
--- a/acbu_lending_pool/tests/test.rs
+++ b/acbu_lending_pool/tests/test.rs
@@ -2,6 +2,7 @@
 
 use acbu_lending_pool::{LendingPool, LendingPoolClient};
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Symbol};
+use shared::DECIMALS;
 // Add these imports for the lifecycle test
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 
@@ -22,7 +23,7 @@ fn test_deposit_and_withdraw() {
     client.initialize(&admin, &acbu_token, &fee_rate);
 
     let lender = Address::generate(&env);
-    let amount = 10_000_000; // 1000 ACBU
+    let amount = DECIMALS; // 1000 ACBU
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
     token_admin.mint(&lender, &amount);
@@ -55,7 +56,7 @@ fn test_withdraw_more_than_balance_fails() {
     client.initialize(&admin, &acbu_token, &fee_rate);
 
     let lender = Address::generate(&env);
-    let amount = 10_000_000;
+    let amount = DECIMALS;
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
     token_admin.mint(&lender, &amount);
     client.deposit(&lender, &amount);
@@ -87,7 +88,7 @@ fn test_unauthorized_deposit_fails() {
 
     let lender = Address::generate(&env);
     let attacker = Address::generate(&env);
-    let amount: i128 = 10_000_000;
+    let amount: i128 = DECIMALS;
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
     token_admin.mint(&lender, &amount);
@@ -133,7 +134,7 @@ fn test_unauthorized_withdraw_fails() {
 
     let lender = Address::generate(&env);
     let attacker = Address::generate(&env);
-    let amount: i128 = 10_000_000;
+    let amount: i128 = DECIMALS;
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
     token_admin.mint(&lender, &amount);

--- a/acbu_minting/tests/test.rs
+++ b/acbu_minting/tests/test.rs
@@ -199,7 +199,7 @@ fn test_mint_from_usdc() {
     let usdc_client = soroban_sdk::token::Client::new(&env, &usdc_token_id);
     let acbu_client = soroban_sdk::token::Client::new(&env, &acbu_token_id);
 
-    let usdc_amount = 100 * 10_000_000;
+    let usdc_amount = 100 * DECIMALS;
     usdc_token_client.mint(&user, &usdc_amount);
 
     init_mint_client(
@@ -216,7 +216,7 @@ fn test_mint_from_usdc() {
         fee_single,
     );
 
-    let mint_amount = 50 * 10_000_000;
+    let mint_amount = 50 * DECIMALS;
     let acbu_minted = client.mint_from_usdc(&user, &mint_amount, &user);
 
     let expected_fee = 15_000_000;
@@ -224,7 +224,7 @@ fn test_mint_from_usdc() {
 
     assert_eq!(acbu_minted, expected_acbu);
     assert_eq!(acbu_client.balance(&user), expected_acbu);
-    assert_eq!(usdc_client.balance(&user), 50 * 10_000_000);
+    assert_eq!(usdc_client.balance(&user), 50 * DECIMALS);
     assert_eq!(client.get_total_supply(), expected_acbu);
 
     let events = env.events().all();
@@ -314,9 +314,9 @@ fn test_mint_insufficient_reserves() {
 
     let user = Address::generate(&env);
     let usdc_sac = soroban_sdk::token::StellarAssetClient::new(&env, &usdc_token);
-    usdc_sac.mint(&user, &10_000_000);
+    usdc_sac.mint(&user, &DECIMALS);
 
-    client.mint_from_usdc(&user, &10_000_000, &user);
+    client.mint_from_usdc(&user, &DECIMALS, &user);
 }
 
 #[test]

--- a/acbu_reserve_tracker/tests/test.rs
+++ b/acbu_reserve_tracker/tests/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use acbu_reserve_tracker::{ReserveTrackerContract, ReserveTrackerContractClient};
-use shared::CurrencyCode;
+use shared::{CurrencyCode, DECIMALS};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env,
@@ -26,8 +26,8 @@ fn verify_reserves_uses_passed_supply_not_contract_balance() {
     client.update_reserve(&admin, &ngn, &1_000_000_000, &100_000_000); // 10 USD @ 7 decimals
 
     // 10 USD reserves vs 10 ACBU supply (10 * 10^7) at 100% min ratio → sufficient
-    assert!(client.verify_reserves(&(10 * 10_000_000)));
+    assert!(client.verify_reserves(&(10 * DECIMALS)));
 
     // Same reserves vs double the supply → insufficient
-    assert!(!client.verify_reserves(&(20 * 10_000_000)));
+    assert!(!client.verify_reserves(&(20 * DECIMALS)));
 }

--- a/acbu_savings_vault/tests/test.rs
+++ b/acbu_savings_vault/tests/test.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     Address, Env, FromVal, IntoVal, Symbol,
 };
+use shared::DECIMALS;
 use acbu_savings_vault::DepositEvent;
 
 const SECONDS_PER_YEAR: u64 = 31_536_000;
@@ -29,7 +30,7 @@ fn test_withdraw_after_term_has_correct_30day_yield() {
     let yield_rate = 1_000; // 10% APR
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
-    let deposit_amount = 10_000_000i128;
+    let deposit_amount = DECIMALS;
     let term_seconds = 30 * 24 * 3600u64; // 2_592_000 seconds
 
     // Expected: 10M * 1000 bps * 2_592_000 / (10000 * 31_536_000) = 82_191
@@ -87,7 +88,7 @@ fn test_withdraw_after_one_year_has_positive_yield_and_event_value() {
     let yield_rate = 1_000; // 10% APR
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
-    let deposit_amount = 10_000_000;
+    let deposit_amount = DECIMALS;
     let expected_fee = 300_000;
     // Base everything on net
     let net_deposit = 9_700_000;
@@ -203,7 +204,7 @@ fn test_early_withdrawal_is_rejected() {
 
     client.initialize(&admin, &acbu_token, &300, &1_000);
 
-    let deposit_amount = 10_000_000;
+    let deposit_amount = DECIMALS;
 
     let net_deposit = 9_700_000;
     let term_seconds: u64 = 30 * 24 * 3600; // 30 days
@@ -245,7 +246,7 @@ fn test_withdraw_at_exact_term_boundary_succeeds() {
     let yield_rate = 0i128;
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
-    let deposit_amount = 10_000_000i128;
+    let deposit_amount = DECIMALS;
     let term_seconds: u64 = 60 * 60; // 1 hour
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
@@ -322,7 +323,7 @@ fn test_deposit_fee_reflected_in_balance() {
     let yield_rate = 0;
     client.initialize(&admin, &acbu_token, &fee_rate, &yield_rate);
 
-    let gross_deposit = 10_000_000i128;
+    let gross_deposit = DECIMALS;
     let expected_fee = 300_000i128;
     let expected_net = 9_700_000i128;
     let term_seconds = 3600u64;
@@ -355,9 +356,9 @@ fn test_deposit_event_has_fee_fields() {
 
     client.initialize(&admin, &acbu_token, &300, &0);
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
-    token_admin.mint(&user, &10_000_000);
+    token_admin.mint(&user, &DECIMALS);
 
-    client.deposit(&user, &10_000_000, &3600);
+    client.deposit(&user, &DECIMALS, &3600);
 
     let events = env.events().all();
     let deposit_event = events.iter().rev().find(|e| {
@@ -365,7 +366,7 @@ fn test_deposit_event_has_fee_fields() {
     }).unwrap();
     let deposit_event: DepositEvent = deposit_event.2.into_val(&env);
 
-    assert_eq!(deposit_event.gross_amount, 10_000_000);
+    assert_eq!(deposit_event.gross_amount, DECIMALS);
     assert_eq!(deposit_event.fee_amount, 300_000);
     assert_eq!(deposit_event.net_amount, 9_700_000);
 }

--- a/tests/integration_rounding.rs
+++ b/tests/integration_rounding.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+
+use shared::{calculate_amount_after_fee, calculate_fee, DECIMALS};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// Minimal consumer contract A that asks an oracle (mocked here) for a rate
+#[contract]
+pub struct ConsumerA;
+
+#[contractimpl]
+impl ConsumerA {
+    pub fn compute_net_after_fee(_env: Env, amount: i128, fee_bps: i128) -> i128 {
+        calculate_amount_after_fee(amount, fee_bps)
+    }
+}
+
+// Minimal consumer contract B that uses the same shared helpers
+#[contract]
+pub struct ConsumerB;
+
+#[contractimpl]
+impl ConsumerB {
+    pub fn compute_fee(_env: Env, amount: i128, fee_bps: i128) -> i128 {
+        calculate_fee(amount, fee_bps)
+    }
+}
+
+#[test]
+fn integration_rounding_consistency() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Deploy both consumer contracts
+    let a_id = env.register_contract(None, ConsumerA);
+    let b_id = env.register_contract(None, ConsumerB);
+
+    let a_client = ConsumerAClient::new(&env, &a_id);
+    let b_client = ConsumerBClient::new(&env, &b_id);
+
+    // Amounts that include small remainders to exercise rounding: e.g., 100 * DECIMALS + 3
+    let amounts = [1 * DECIMALS, 100 * DECIMALS + 3, 7 * DECIMALS + 1];
+    let fee_bps = 123; // 1.23%
+
+    for &amt in amounts.iter() {
+        let fee = b_client.compute_fee(&amt, &fee_bps);
+        let net = a_client.compute_net_after_fee(&amt, &fee_bps);
+        // fee + net must equal original amount
+        assert_eq!(fee + net, amt);
+        // fee must match shared helper directly
+        assert_eq!(fee, calculate_fee(amt, fee_bps));
+    }
+}


### PR DESCRIPTION
Summary: Replace hard-coded 7-decimal literals with the central [DECIMALS](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) constant and add a workspace integration test to assert cross-contract rounding/fee consistency.



closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test inputs across all modules to use shared decimal constants instead of hardcoded values
  * Added comprehensive integration test suite for rounding verification to validate fee calculations and ensure amount reconstruction accuracy

* **Chores**
  * Enhanced test code consistency and maintainability across multiple test modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->