### PR TITLE
fix(burning): C-057 - validate recipients non-empty and distinct in r…

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env,
+    contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env,
     IntoVal, String as SorobanString, Symbol, Vec,
 };
 
 use shared::{
     calculate_fee, BurnEvent, ContractError, CurrencyCode, DataKey as SharedDataKey, BASIS_POINTS,
-    CONTRACT_VERSION, DECIMALS, MIN_BURN_AMOUNT, UPDATE_INTERVAL_SECONDS,
+    DECIMALS, MIN_BURN_AMOUNT, UPDATE_INTERVAL_SECONDS,
 };
 
 mod shared {
@@ -228,14 +228,35 @@ impl BurningContract {
     }
 
     /// Redeem ACBU for proportional Afreum S-tokens across the basket (lower fee tier).
+    ///
+    /// `recipients` must be non-empty and contain no duplicate addresses — one entry per
+    /// basket currency (in the same order returned by the oracle's `get_currencies`).
+    /// Duplicate or empty recipient lists are rejected to prevent double-payment in
+    /// off-chain mapping (C-057).
     pub fn redeem_basket(
         env: Env,
         user: Address,
-        recipient: Address,
+        recipients: Vec<Address>,
         acbu_amount: i128,
     ) -> Vec<i128> {
         Self::check_paused(&env);
         user.require_auth();
+
+        // C-057: Validate recipients list is non-empty.
+        if recipients.is_empty() {
+            env.panic_with_error(ContractError::InvalidRecipient);
+        }
+
+        // C-057: Enforce all recipient addresses are distinct.
+        // O(n²) is acceptable here — basket sizes are small (≤ ~20 currencies).
+        let rlen = recipients.len();
+        for i in 0..rlen {
+            for j in (i + 1)..rlen {
+                if recipients.get(i).unwrap() == recipients.get(j).unwrap() {
+                    env.panic_with_error(ContractError::InvalidRecipient);
+                }
+            }
+        }
 
         let min_amount: i128 = env
             .storage()
@@ -314,6 +335,14 @@ impl BurningContract {
         let mut amounts_out = Vec::new(&env);
         for i in 0..currencies.len() {
             let currency = currencies.get(i).unwrap();
+
+            // C-057: Each currency slot maps to the corresponding recipient by index.
+            // If the caller supplied fewer recipients than currencies, reject.
+            if i >= recipients.len() {
+                env.panic_with_error(ContractError::InvalidRecipient);
+            }
+            let recipient = recipients.get(i).unwrap();
+
             let weight: i128 = env.invoke_contract(
                 &oracle_addr,
                 &Symbol::new(&env, "get_basket_weight"),

--- a/acbu_burning/tests/test.rs
+++ b/acbu_burning/tests/test.rs
@@ -2,7 +2,7 @@
 
 use acbu_burning::{BurningContract, BurningContractClient};
 use shared::{CurrencyCode, DECIMALS};
-use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Address as _, Address, Env};
+use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Address as _, vec, Address, Env, Vec};
 
 mod oracle_mock {
     use super::*;
@@ -166,7 +166,6 @@ fn test_redeem_basket() {
 
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
-    let recipient = Address::generate(&env);
 
     let oracle = env.register_contract(None, oracle_mock::MockOracle);
     let reserve_tracker = env.register_contract(None, oracle_mock::MockReserveTracker);
@@ -201,7 +200,13 @@ fn test_redeem_basket() {
     let token = soroban_sdk::token::Client::new(&env, &stoken);
     token.approve(&vault, &contract_id, &1_000_000_000_000_000, &100u32);
 
-    let amounts = client.redeem_basket(&user, &recipient, &burn_amt);
+    // C-057: provide 3 distinct recipients (one per basket currency)
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    let recipients = vec![&env, r1, r2, r3];
+
+    let amounts = client.redeem_basket(&user, &recipients, &burn_amt);
     assert_eq!(amounts.len(), 3);
 
     let mut total_out = 0i128;
@@ -211,4 +216,69 @@ fn test_redeem_basket() {
     // With DECIMALS matching and weight sum = 10000, out should be burn_amt - fee
     let expected_fee = (burn_amt * 100) / 10_000;
     assert_eq!(total_out + expected_fee, burn_amt);
+}
+
+// C-057: empty recipients list must be rejected
+#[test]
+fn test_redeem_basket_rejects_empty_recipients() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let oracle = env.register_contract(None, oracle_mock::MockOracle);
+    let reserve_tracker = env.register_contract(None, oracle_mock::MockReserveTracker);
+    let acbu_token = env.register_contract(None, oracle_mock::MockToken);
+    let stoken = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    oracle_mock::MockOracleClient::new(&env, &oracle).seed_stoken(&stoken);
+
+    let contract_id = env.register_contract(None, BurningContract);
+    let client = BurningContractClient::new(&env, &contract_id);
+
+    let vault = admin.clone();
+    client.initialize(
+        &admin, &oracle, &reserve_tracker, &acbu_token,
+        &Address::generate(&env), &vault, &100, &150,
+    );
+
+    let empty: Vec<Address> = Vec::new(&env);
+    let result = client.try_redeem_basket(&user, &empty, &(100 * DECIMALS));
+    assert!(result.is_err());
+}
+
+// C-057: duplicate recipients must be rejected
+#[test]
+fn test_redeem_basket_rejects_duplicate_recipients() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let oracle = env.register_contract(None, oracle_mock::MockOracle);
+    let reserve_tracker = env.register_contract(None, oracle_mock::MockReserveTracker);
+    let acbu_token = env.register_contract(None, oracle_mock::MockToken);
+    let stoken = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    oracle_mock::MockOracleClient::new(&env, &oracle).seed_stoken(&stoken);
+
+    let contract_id = env.register_contract(None, BurningContract);
+    let client = BurningContractClient::new(&env, &contract_id);
+
+    let vault = admin.clone();
+    client.initialize(
+        &admin, &oracle, &reserve_tracker, &acbu_token,
+        &Address::generate(&env), &vault, &100, &150,
+    );
+
+    let dup = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    // First and third are the same — duplicate
+    let recipients = vec![&env, dup.clone(), r2, dup.clone()];
+    let result = client.try_redeem_basket(&user, &recipients, &(100 * DECIMALS));
+    assert!(result.is_err());
 }


### PR DESCRIPTION
closes #136 

Fixes C-057 — the `redeem_basket` burn path accepted a single `recipient: Address`
shared across all basket currencies, meaning duplicate or empty recipient inputs
could cause double-payment in off-chain mapping.

## Changes

### acbu_burning/src/lib.rs
- Changed `redeem_basket` signature: `recipient: Address` → `recipients: Vec<Address>`
- Each entry maps 1-to-1 with the oracle's currency list (same index order)
- Empty list → panics with `ContractError::InvalidRecipient`
- Duplicate addresses → pairwise check, panics with `ContractError::InvalidRecipient`
- Each currency slot transfers to its own indexed recipient

### acbu_burning/tests/test.rs
- Updated `test_redeem_basket` to pass 3 distinct recipients (one per NGN/KES/GHS)
- Added `test_redeem_basket_rejects_empty_recipients`
- Added `test_redeem_basket_rejects_duplicate_recipients`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Basket redemption functionality now supports specifying multiple recipient addresses in a single operation, enabling distribution of redeemed funds across multiple beneficiaries.

* **Bug Fixes**
  * Added validation to ensure recipient lists are properly configured, rejecting empty lists and preventing duplicate addresses in redemption requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->