### PR TITLE
tests: add escrow full lifecycle integration tests (#129 C-050)

### DIFF
--- a/acbu_escrow/tests/test_full_lifecycle.rs
+++ b/acbu_escrow/tests/test_full_lifecycle.rs
@@ -1,0 +1,129 @@
+#![cfg(test)]
+
+use acbu_escrow::{Escrow, EscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, Error, IntoVal,
+};
+
+#[test]
+fn test_happy_path_create_fund_release() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let escrow_id = 1u64;
+    let amount = 5_000_000i128;
+
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    env.mock_all_auths();
+    token_admin.mint(&payer, &amount);
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+    client.create(&payer, &payee, &amount, &escrow_id).unwrap();
+
+    // payer authorizes release
+    env.mock_auths(&[MockAuth {
+        address: &payer,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "release",
+            args: (escrow_id, payer.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.release(&escrow_id, &payer).unwrap();
+
+    let token = soroban_sdk::token::Client::new(&env, &acbu_token);
+    assert_eq!(token.balance(&payee), amount);
+
+    // after release the escrow must no longer exist
+    let result = client.try_release(&escrow_id, &payer);
+    assert_eq!(result, Err(Ok(Error::from_contract_error(3003))));
+}
+
+#[test]
+fn test_admin_refund_on_dispute() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let escrow_id = 7u64;
+    let amount = 2_500_000i128;
+
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    env.mock_all_auths();
+    token_admin.mint(&payer, &amount);
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+    client.create(&payer, &payee, &amount, &escrow_id).unwrap();
+
+    // admin authorizes refund (dispute resolution)
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "refund",
+            args: (escrow_id, payer.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.refund(&escrow_id, &payer).unwrap();
+
+    let token = soroban_sdk::token::Client::new(&env, &acbu_token);
+    assert_eq!(token.balance(&payer), amount);
+
+    // after refund the escrow must no longer exist
+    let result = client.try_refund(&escrow_id, &payer);
+    assert_eq!(result, Err(Ok(Error::from_contract_error(3003))));
+}
+
+#[test]
+fn test_adversarial_release_by_non_payer_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let escrow_id = 42u64;
+    let amount = 1_000_000i128;
+
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
+    env.mock_all_auths();
+    token_admin.mint(&payer, &amount);
+
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &acbu_token);
+    client.create(&payer, &payee, &amount, &escrow_id).unwrap();
+
+    // attacker tries to call release without payer auth
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "release",
+            args: (escrow_id, payer.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_release(&escrow_id, &payer);
+    assert!(result.is_err(), "Release without payer auth must fail");
+}


### PR DESCRIPTION
Summary

What: Adds end-to-end escrow integration tests exercising create/fund/release/refund and adversarial release cases.
Why: Prevent regressions from recent escrow fixes (issue #129 C-050) and validate full lifecycle behavior.



closes #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating the complete escrow lifecycle, including token operations, contract initialization, authorized release and refund operations, and error handling for unauthorized access attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->