### PR TITLE
Oracle RateUpdateEvent validators empty

### DIFF
--- a/acbu_oracle/README.md
+++ b/acbu_oracle/README.md
@@ -70,7 +70,7 @@ pub struct RateUpdateEvent {
     pub currency: CurrencyCode,
     pub rate: i128,
     pub timestamp: u64,
-    pub validators: Vec<Address>,
+    pub validator: Address,
 }
 ```
 

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -403,7 +403,7 @@ impl OracleContract {
             currency: currency.clone(),
             rate: median_rate,
             timestamp: current_time,
-            validators,
+            validator: validator.clone(),
         };
         env.events().publish((symbol_short!("rate_upd"),), event);
     }

--- a/acbu_oracle/tests/test.rs
+++ b/acbu_oracle/tests/test.rs
@@ -109,7 +109,7 @@ fn test_update_rate() {
             let event_data: RateUpdateEvent = event.2.into_val(&env);
             assert_eq!(event_data.currency, ngn.clone());
             assert_eq!(event_data.rate, 1235000);
-            assert_eq!(event_data.validators, validators);
+            assert_eq!(event_data.validator, validator);
             found = true;
             break;
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -108,7 +108,7 @@ pub struct RateUpdateEvent {
     pub currency: CurrencyCode,
     pub rate: i128,
     pub timestamp: u64,
-    pub validators: soroban_sdk::Vec<Address>,
+    pub validator: Address,
 }
 
 /// Outlier detection event data


### PR DESCRIPTION
Closes #110 

Updated [lib.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) struct from [pub validators: Vec<Address>](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [pub validator: Address](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated [lib.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Modified the event creation in [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to set [validator: validator.clone()](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of the full validators list.
Updated [test.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed the test assertion to check [event_data.validator == validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated [README.md](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Reflected the struct change in the documentation.
Testing Steps:
Follow these steps in your development environment to verify the assignment is completed:

Build the Contracts:

Expected Outcome: The build should complete without errors. If there are compilation issues, check for any breaking changes in dependent code.
Run the Oracle Contract Tests:

Expected Outcome: All tests should pass, including [test_update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [test_outlier_detection](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Specifically, the [test_update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) test should verify that the [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now includes the contributing validator in the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field.
Inspect the Event in Tests:

In the test output or by adding debug prints, confirm that the event data has [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) set to the [Address](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) of the validator that called [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The event should no longer include the full validator set, but the specific contributor.
Run All Tests:

Expected Outcome: The entire test suite passes, ensuring no regressions in other contracts that might use the shared [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Deploy to Testnet (Optional for Full Validation):

Follow the deployment steps in [deploy_testnet.sh](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
After deployment, simulate a rate update by calling [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from a validator account.
Query the contract events or use Soroban CLI to inspect emitted events.
Verify that the [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) includes the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field with the correct contributing validator address.
Acceptance Check:

The event now includes non-empty validator metadata (the specific validator that contributed).
Downstream systems can audit which validator contributed to each rate update by checking the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field in the event.Updated [lib.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) struct from [pub validators: Vec<Address>](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [pub validator: Address](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated [lib.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Modified the event creation in [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to set [validator: validator.clone()](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of the full validators list.
Updated [test.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed the test assertion to check [event_data.validator == validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated [README.md](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Reflected the struct change in the documentation.
Testing Steps:
Follow these steps in your development environment to verify the assignment is completed:

Build the Contracts:

Expected Outcome: The build should complete without errors. If there are compilation issues, check for any breaking changes in dependent code.
Run the Oracle Contract Tests:

Expected Outcome: All tests should pass, including [test_update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [test_outlier_detection](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Specifically, the [test_update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) test should verify that the [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now includes the contributing validator in the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field.
Inspect the Event in Tests:

In the test output or by adding debug prints, confirm that the event data has [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) set to the [Address](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) of the validator that called [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The event should no longer include the full validator set, but the specific contributor.
Run All Tests:

Expected Outcome: The entire test suite passes, ensuring no regressions in other contracts that might use the shared [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Deploy to Testnet (Optional for Full Validation):

Follow the deployment steps in [deploy_testnet.sh](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
After deployment, simulate a rate update by calling [update_rate](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from a validator account.
Query the contract events or use Soroban CLI to inspect emitted events.
Verify that the [RateUpdateEvent](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) includes the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field with the correct contributing validator address.
Acceptance Check:

The event now includes non-empty validator metadata (the specific validator that contributed).
Downstream systems can audit which validator contributed to each rate update by checking the [validator](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field in the event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rate update events to report the specific validator address instead of the full validator list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->