### PR TITLE
fix(lending-pool): apply fee rate to loan repayment accrual

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -79,6 +79,10 @@ pub struct LendingPool;
 
 #[contractimpl]
 impl LendingPool {
+    /// Initialize the pool.
+    ///
+    /// `fee_rate_bps` is the annualized loan fee rate in basis points. It is
+    /// snapshotted into each loan and accrued into `total_repayment_due`.
     pub fn initialize(env: Env, admin: Address, acbu_token: Address, fee_rate_bps: i128) {
         if env.storage().instance().has(&DataKey::Admin) {
             env.panic_with_error(Error::AlreadyInitialized);
@@ -254,17 +258,25 @@ impl LendingPool {
     pub fn get_loan(env: Env, borrower: Address, loan_id: u64) -> Option<LoanData> {
         let loan_key = LoanId(borrower, loan_id);
         let mut loan_data: LoanData = env.storage().persistent().get(&DataKey::Loan(loan_key))?;
-        
+
         let current_time = env.ledger().timestamp();
         let elapsed = current_time.saturating_sub(loan_data.loan_start_timestamp);
-        
-        let year_secs: u64 = 365 * 24 * 60 * 60;
-        let new_interest = (loan_data.amount as i128 * loan_data.interest_rate_bps as i128 * elapsed as i128) 
-            / (10000 * year_secs as i128);
-            
-        loan_data.accrued_interest += new_interest;
-        loan_data.total_repayment_due = loan_data.amount + loan_data.accrued_interest;
-        
+
+        let accrued_fee = Self::calculate_accrued_fee(
+            &env,
+            loan_data.amount,
+            loan_data.interest_rate_bps,
+            elapsed,
+        );
+        loan_data.accrued_interest = loan_data
+            .accrued_interest
+            .checked_add(accrued_fee)
+            .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount));
+        loan_data.total_repayment_due = loan_data
+            .amount
+            .checked_add(loan_data.accrued_interest)
+            .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount));
+
         Some(loan_data)
     }
 
@@ -316,8 +328,11 @@ impl LendingPool {
                 0
             };
             loan_data.accrued_interest = remaining_interest;
-            loan_data.total_repayment_due = loan_data.amount + remaining_interest;
-            
+            loan_data.total_repayment_due = loan_data
+                .amount
+                .checked_add(remaining_interest)
+                .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount));
+
             env.storage()
                 .persistent()
                 .set(&DataKey::Loan(loan_key), &loan_data);
@@ -387,6 +402,21 @@ impl LendingPool {
         if paused {
             env.panic_with_error(Error::Paused);
         }
+    }
+
+    fn calculate_accrued_fee(
+        env: &Env,
+        principal: i128,
+        fee_rate_bps: u32,
+        elapsed_seconds: u64,
+    ) -> i128 {
+        const SECONDS_PER_YEAR: i128 = 31_536_000;
+
+        principal
+            .checked_mul(i128::from(fee_rate_bps))
+            .and_then(|v| v.checked_mul(i128::from(elapsed_seconds)))
+            .and_then(|v| v.checked_div(BASIS_POINTS * SECONDS_PER_YEAR))
+            .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount))
     }
 }
 

--- a/acbu_lending_pool/tests/test.rs
+++ b/acbu_lending_pool/tests/test.rs
@@ -1,13 +1,13 @@
 #![cfg(test)]
 
-use acbu_lending_pool::{BorrowEvent, RepayEvent, LendingPool, LendingPoolClient};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, TryIntoVal};
-use acbu_lending_pool::{Error, LendingPool, LendingPoolClient};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Symbol};
-use shared::DECIMALS;
-// Add these imports for the lifecycle test
-use soroban_sdk::testutils::Events;
-use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use acbu_lending_pool::{BorrowEvent, LendingPool, LendingPoolClient, RepayEvent};
+use shared::{BASIS_POINTS, DECIMALS};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, TryIntoVal,
+};
 
 #[test]
 fn test_deposit_and_withdraw() {
@@ -214,6 +214,50 @@ fn test_borrow_basic() {
         token_client.balance(&contract_id),
         pool_liquidity - borrow_amount
     );
+}
+
+#[test]
+fn test_fee_rate_accrues_into_repayment_due() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let admin = Address::generate(&env);
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register_contract(None, LendingPool);
+    let client = LendingPoolClient::new(&env, &contract_id);
+    let fee_rate_bps = 1_000i128;
+    client.initialize(&admin, &acbu_token, &fee_rate_bps);
+
+    let token_admin = StellarAssetClient::new(&env, &acbu_token);
+
+    let lender = Address::generate(&env);
+    let pool_liquidity = 1_000_000i128;
+    token_admin.mint(&lender, &pool_liquidity);
+    client.deposit(&lender, &pool_liquidity);
+
+    let borrower = Address::generate(&env);
+    let borrow_amount = 100_000i128;
+    let collateral = borrow_amount;
+    token_admin.mint(&borrower, &(collateral + borrow_amount));
+
+    let loan_id = 226u64;
+    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+
+    let elapsed = 365u64 * 24 * 60 * 60 / 2;
+    env.ledger().with_mut(|l| l.timestamp += elapsed);
+
+    let loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("loan must exist");
+    let expected_fee =
+        borrow_amount * fee_rate_bps * i128::from(elapsed) / (BASIS_POINTS * 31_536_000);
+
+    assert_eq!(loan.accrued_interest, expected_fee);
+    assert_eq!(loan.total_repayment_due, borrow_amount + expected_fee);
 }
 
 /// 2. Basic repay: borrower repays the full loan.


### PR DESCRIPTION
closes #226 
##Summary
Clarifies fee_rate_bps as the annualized lending fee rate.
Applies the configured fee rate to loan repayment calculations through checked accrual math.
Adds regression coverage proving a nonzero fee rate increases total_repayment_due.
Keeps the fix scoped to lending pool fee usage only.

##Reason
Issue #226 noted that the lending pool fee rate was stored but not clearly applied to operations. This change makes fee-rate application explicit, safe, and covered by tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved loan interest accrual and repayment calculation for greater consistency and numerical safety, ensuring accurate totals are stored and used during repayment.

* **Tests**
  * Added an integration test confirming interest and total repayment amounts accrue correctly over elapsed time based on configured fee rates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-smart-contract/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->