### PR TITLE
fix: improve burning recipient validation

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -5,12 +5,10 @@ use soroban_sdk::{
 };
 
 use shared::{
-    calculate_fee, BurnEvent, CurrencyCode, DataKey as SharedDataKey, BASIS_POINTS,
-    CONTRACT_VERSION, DECIMALS, MIN_BURN_AMOUNT,
-    ORACLE_GET_ACBU_RATE, ORACLE_GET_CURRENCIES, ORACLE_GET_BASKET_WEIGHT,
-    ORACLE_GET_RATE, ORACLE_GET_S_TOKEN_ADDR,
-    calculate_fee, BurnEvent, ContractError, CurrencyCode, DataKey as SharedDataKey, BASIS_POINTS,
-    DECIMALS, MIN_BURN_AMOUNT, UPDATE_INTERVAL_SECONDS,
+    calculate_fee, BurnEvent, ContractError, CurrencyCode, DataKey as SharedDataKey,
+    BASIS_POINTS, CONTRACT_VERSION, DECIMALS, MIN_BURN_AMOUNT,
+    ORACLE_GET_ACBU_RATE, ORACLE_GET_BASKET_WEIGHT, ORACLE_GET_CURRENCIES,
+    ORACLE_GET_RATE, ORACLE_GET_S_TOKEN_ADDR, UPDATE_INTERVAL_SECONDS,
 };
 
 #[allow(dead_code)]
@@ -99,7 +97,7 @@ impl BurningContract {
         env.storage()
             .instance()
             .set(&DATA_KEY.fee_single_redeem, &fee_single_redeem_bps);
-        env.storage().instance().set(&SharedDataKey::Version, &2u32);
+        env.storage().instance().set(&SharedDataKey::Version, &CONTRACT_VERSION);
         env.storage().instance().set(&DATA_KEY.paused, &false);
         env.storage()
             .instance()
@@ -357,15 +355,6 @@ impl BurningContract {
         let mut amounts_out = Vec::new(&env);
         for i in 0..currencies.len() {
             let currency = currencies.get(i).unwrap();
-            let weight: i128 = env.invoke_contract(
-                &oracle_addr,
-                &Symbol::new(&env, ORACLE_GET_BASKET_WEIGHT),
-                vec![&env, currency.into_val(&env)],
-            );
-            if weight > 0 {
-                last_weighted_idx = Some(i);
-            }
-        }
 
             // C-057: Each currency slot maps to the corresponding recipient by index.
             // If the caller supplied fewer recipients than currencies, reject.
@@ -378,8 +367,6 @@ impl BurningContract {
                 &oracle_addr,
                 &Symbol::new(&env, ORACLE_GET_BASKET_WEIGHT),
                 vec![&env, currency.clone().into_val(&env)],
-                &Symbol::new(&env, "get_basket_weight"),
-                vec![&env, currency.into_val(&env)],
             );
             if weight == 0 {
                 amounts_out.push_back(0);


### PR DESCRIPTION
acbu_burning/src/lib.rs: recipient_accounts.len() == 0 could be recipient_accounts.is_empty().

closes #246 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated contract initialization to reference shared version constants instead of hardcoded values, improving version management
  * Enhanced basket redemption logic with consistent currency value handling during oracle calls
  * Optimized import structure by removing duplicated fragments and consolidating shared oracle constant references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-smart-contract/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->