### PR TITLE
fix(burning): fix #201 basket redemption dust allocation

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -1,38 +1,14 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, Env,
-    IntoVal, Symbol, Vec,
-};
-
-use shared::{
-    calculate_fee, ContractError, CurrencyCode, DataKey as SharedDataKey, BASIS_POINTS,
-    DECIMALS, MIN_BURN_AMOUNT, ORACLE_GET_CURRENCIES, ORACLE_GET_BASKET_WEIGHT,
-    ORACLE_GET_RATE, ORACLE_GET_S_TOKEN_ADDR,
-};
-
     contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env, IntoVal,
     String as SorobanString, Symbol, Vec,
 };
 
 use shared::{
-    calculate_fee, BurnEvent, ContractError, CurrencyCode, DataKey as SharedDataKey, BASIS_POINTS,
-    CONTRACT_VERSION, DECIMALS, MIN_BURN_AMOUNT,
-    ORACLE_GET_ACBU_RATE, ORACLE_GET_CURRENCIES, ORACLE_GET_BASKET_WEIGHT,
-    ORACLE_GET_RATE, ORACLE_GET_S_TOKEN_ADDR, UPDATE_INTERVAL_SECONDS,
+    calculate_fee, reentrancy_guard, BurnEvent, ContractError, CurrencyCode,
+    DataKey as SharedDataKey, CONTRACT_VERSION, MIN_BURN_AMOUNT, ORACLE_GET_ACBU_RATE_WITH_TS,
+    ORACLE_GET_BASKET_WEIGHT, ORACLE_GET_CURRENCIES, ORACLE_GET_RATE_WITH_TS,
+    ORACLE_GET_S_TOKEN_ADDR, UPDATE_INTERVAL_SECONDS,
 };
-
-mod shared {
-    pub use shared::*;
-}
-
-/*
-#[allow(dead_code)]
-pub mod token_contract {
-    soroban_sdk::contractimport!(
-        file = "../soroban_token_contract.wasm",
-        sha256 = "eb1a53948744e12a6b00ec891b301ebc78a06deb984d3726c9cbc315392aedec"
-    );
-}
-*/
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -67,29 +43,48 @@ pub struct BurningContract;
 
 #[contractimpl]
 impl BurningContract {
-    pub fn initialize(env: Env, admin: Address, oracle: Address, reserve_tracker: Address, acbu_token: Address, withdrawal_processor: Address, vault: Address, fee_rate_bps: i128, fee_single_redeem_bps: i128) {
-        if env.storage().instance().has(&DATA_KEY.admin) { env.panic_with_error(ContractError::Unauthorized); }
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        oracle: Address,
+        reserve_tracker: Address,
+        acbu_token: Address,
+        withdrawal_processor: Address,
+        vault: Address,
+        fee_rate_bps: i128,
+        fee_single_redeem_bps: i128,
+    ) {
+        if env.storage().instance().has(&DATA_KEY.admin) {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
         env.storage().instance().set(&DATA_KEY.admin, &admin);
         env.storage().instance().set(&DATA_KEY.oracle, &oracle);
-        env.storage().instance().set(&DATA_KEY.reserve_tracker, &reserve_tracker);
-        env.storage().instance().set(&DATA_KEY.acbu_token, &acbu_token);
-        env.storage().instance().set(&DATA_KEY.withdrawal_processor, &withdrawal_processor);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.reserve_tracker, &reserve_tracker);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.acbu_token, &acbu_token);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.withdrawal_processor, &withdrawal_processor);
         env.storage().instance().set(&DATA_KEY.vault, &vault);
-        env.storage().instance().set(&DATA_KEY.fee_rate, &fee_rate_bps);
-        env.storage().instance().set(&DATA_KEY.fee_single_redeem, &fee_single_redeem_bps);
-        env.storage().instance().set(&SharedDataKey::Version, &2u32);
         env.storage()
             .instance()
             .set(&DATA_KEY.fee_rate, &fee_rate_bps);
         env.storage()
             .instance()
             .set(&DATA_KEY.fee_single_redeem, &fee_single_redeem_bps);
-        env.storage().instance().set(&SharedDataKey::Version, &CONTRACT_VERSION);
+        env.storage()
+            .instance()
+            .set(&SharedDataKey::Version, &CONTRACT_VERSION);
         env.storage().instance().set(&DATA_KEY.paused, &false);
-        env.storage().instance().set(&DATA_KEY.min_burn_amount, &MIN_BURN_AMOUNT);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.min_burn_amount, &MIN_BURN_AMOUNT);
     }
 
-    pub fn redeem_basket(env: Env, user: Address, recipients: Vec<Address>, acbu_amount: i128) -> Vec<i128> {
     /// Redeem ACBU for a single Afreum S-token (higher fee tier). Requires vault approval.
     pub fn redeem_single(
         env: Env,
@@ -98,21 +93,22 @@ impl BurningContract {
         acbu_amount: i128,
         currency: CurrencyCode,
     ) -> i128 {
-        // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
 
         Self::check_paused(&env);
         user.require_auth();
 
+        let min_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.min_burn_amount)
+            .unwrap();
+        if acbu_amount < min_amount {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+
         let oracle_addr: Address = env.storage().instance().get(&DATA_KEY.oracle).unwrap();
         let vault: Address = env.storage().instance().get(&DATA_KEY.vault).unwrap();
-        let _acbu_token: Address = env.storage().instance().get(&DATA_KEY.acbu_token).unwrap();
-        let fee_rate: i128 = env.storage().instance().get(&DATA_KEY.fee_rate).unwrap();
-        let _reserve_tracker_addr: Address = env.storage().instance().get(&DATA_KEY.reserve_tracker).unwrap();
-
-        let total_fee = calculate_fee(acbu_amount, fee_rate);
-        let net_acbu = acbu_amount.checked_sub(total_fee).expect("Underflow");
-        let usd_total = net_acbu.checked_mul(100).and_then(|v| v.checked_div(DECIMALS)).expect("Overflow");
         let acbu_token: Address = env.storage().instance().get(&DATA_KEY.acbu_token).unwrap();
         let fee_single: i128 = env
             .storage()
@@ -125,20 +121,19 @@ impl BurningContract {
             .get(&DATA_KEY.reserve_tracker)
             .unwrap();
 
-        // C-012: Ensure oracle rates are fresh before burning.
+        let current_time = env.ledger().timestamp();
         let (acbu_rate, oracle_timestamp): (i128, u64) = env.invoke_contract(
             &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_ACBU_RATE),
+            &Symbol::new(&env, ORACLE_GET_ACBU_RATE_WITH_TS),
             vec![&env],
         );
-        let current_time = env.ledger().timestamp();
         if current_time > oracle_timestamp.saturating_add(UPDATE_INTERVAL_SECONDS) {
             env.panic_with_error(ContractError::OracleError);
         }
 
         let (rate, rate_timestamp): (i128, u64) = env.invoke_contract(
             &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_RATE),
+            &Symbol::new(&env, ORACLE_GET_RATE_WITH_TS),
             vec![&env, currency.clone().into_val(&env)],
         );
         if current_time > rate_timestamp.saturating_add(UPDATE_INTERVAL_SECONDS) {
@@ -159,28 +154,12 @@ impl BurningContract {
         let net_acbu = acbu_amount
             .checked_sub(fee)
             .expect("Underflow in net acbu calculation");
-
-        // C-019: stoken_out = (net_acbu * acbu_rate) / rate
-        // The redundant (net_acbu * DECIMALS) / DECIMALS scaling is removed — it cancels out.
         let stoken_out = net_acbu
             .checked_mul(acbu_rate)
             .and_then(|v| v.checked_div(rate))
             .expect("Overflow in stoken out calculation");
 
-        // C-012: Call reserve tracker to verify protocol health before burning.
-        let current_supply: i128 = env.invoke_contract(
-            &acbu_token,
-            &Symbol::new(&env, "get_total_supply"),
-            vec![&env],
-        );
-        let reserve_ok: bool = env.invoke_contract(
-            &reserve_tracker_addr,
-            &Symbol::new(&env, "is_reserve_sufficient"),
-            vec![&env, current_supply.into_val(&env)],
-        );
-        if !reserve_ok {
-            env.panic_with_error(ContractError::InsufficientReserves);
-        }
+        Self::check_reserves(&env, &acbu_token, &reserve_tracker_addr);
 
         let acbu_client = soroban_sdk::token::Client::new(&env, &acbu_token);
         acbu_client.burn(&user, &acbu_amount);
@@ -189,14 +168,13 @@ impl BurningContract {
         let spender = env.current_contract_address();
         token.transfer_from(&spender, &vault, &recipient, &stoken_out);
 
-        let tx_id = SorobanString::from_str(&env, "redeem_single");
         let burn_event = BurnEvent {
-            transaction_id: tx_id,
+            transaction_id: SorobanString::from_str(&env, "redeem_single"),
             user: user.clone(),
             acbu_amount,
             net_acbu,
             local_amount: stoken_out,
-            currency: currency.clone(),
+            currency,
             fee,
             rate,
             timestamp: env.ledger().timestamp(),
@@ -204,36 +182,26 @@ impl BurningContract {
         env.events()
             .publish((symbol_short!("burn"), user), burn_event);
 
-        // Release re-entrancy guard
         reentrancy_guard::release_guard(&env);
-
         stoken_out
     }
 
     /// Redeem ACBU for proportional Afreum S-tokens across the basket (lower fee tier).
-    ///
-    /// `recipients` must be non-empty and contain no duplicate addresses — one entry per
-    /// basket currency (in the same order returned by the oracle's `get_currencies`).
-    /// Duplicate or empty recipient lists are rejected to prevent double-payment in
-    /// off-chain mapping (C-057).
     pub fn redeem_basket(
         env: Env,
         user: Address,
         recipients: Vec<Address>,
         acbu_amount: i128,
     ) -> Vec<i128> {
-        // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
 
         Self::check_paused(&env);
         user.require_auth();
 
-        // C-057: Validate recipients list is non-empty.
         if recipients.is_empty() {
             env.panic_with_error(ContractError::InvalidRecipient);
         }
 
-        // C-057: Enforce all recipient addresses are distinct.
         let rlen = recipients.len();
         for i in 0..rlen {
             for j in (i + 1)..rlen {
@@ -262,19 +230,54 @@ impl BurningContract {
             .get(&DATA_KEY.reserve_tracker)
             .unwrap();
 
-        // C-012: Ensure oracle rates are fresh before burning.
+        let current_time = env.ledger().timestamp();
         let (acbu_rate, oracle_timestamp): (i128, u64) = env.invoke_contract(
             &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_ACBU_RATE),
+            &Symbol::new(&env, ORACLE_GET_ACBU_RATE_WITH_TS),
             vec![&env],
         );
-        let current_time = env.ledger().timestamp();
         if current_time > oracle_timestamp.saturating_add(UPDATE_INTERVAL_SECONDS) {
             env.panic_with_error(ContractError::OracleError);
         }
-
         if acbu_rate <= 0 {
             env.panic_with_error(ContractError::InvalidRate);
+        }
+
+        let currencies: Vec<CurrencyCode> = env.invoke_contract(
+            &oracle_addr,
+            &Symbol::new(&env, ORACLE_GET_CURRENCIES),
+            vec![&env],
+        );
+        if currencies.is_empty() {
+            env.panic_with_error(ContractError::InvalidCurrency);
+        }
+        if recipients.len() != currencies.len() {
+            env.panic_with_error(ContractError::InvalidRecipient);
+        }
+
+        let mut weights = Vec::new(&env);
+        let mut total_weight = 0i128;
+        let mut last_positive_weight_index = None;
+        for i in 0..currencies.len() {
+            let currency = currencies.get(i).unwrap();
+            let weight: i128 = env.invoke_contract(
+                &oracle_addr,
+                &Symbol::new(&env, ORACLE_GET_BASKET_WEIGHT),
+                vec![&env, currency.into_val(&env)],
+            );
+            if weight < 0 {
+                env.panic_with_error(ContractError::InvalidAmount);
+            }
+            if weight > 0 {
+                total_weight = total_weight
+                    .checked_add(weight)
+                    .expect("Overflow in total basket weight");
+                last_positive_weight_index = Some(i);
+            }
+            weights.push_back(weight);
+        }
+        if total_weight <= 0 {
+            env.panic_with_error(ContractError::InvalidCurrency);
         }
 
         let total_fee = calculate_fee(acbu_amount, fee_rate);
@@ -282,74 +285,60 @@ impl BurningContract {
             .checked_sub(total_fee)
             .expect("Underflow in net acbu calculation");
 
-        // usd_total = (net_acbu * acbu_rate) / DECIMALS
-        let usd_total = net_acbu
-            .checked_mul(acbu_rate)
-            .and_then(|v| v.checked_div(DECIMALS))
-            .expect("Overflow in usd total calculation");
-
-        // C-012: Call reserve tracker to verify protocol health before burning.
-        let current_supply: i128 = env.invoke_contract(
-            &acbu_token,
-            &Symbol::new(&env, "get_total_supply"),
-            vec![&env],
-        );
-        let reserve_ok: bool = env.invoke_contract(
-            &reserve_tracker_addr,
-            &Symbol::new(&env, "is_reserve_sufficient"),
-            vec![&env, current_supply.into_val(&env)],
-        );
-        if !reserve_ok {
-            env.panic_with_error(ContractError::InsufficientReserves);
-        }
+        Self::check_reserves(&env, &acbu_token, &reserve_tracker_addr);
 
         let acbu_client = soroban_sdk::token::Client::new(&env, &acbu_token);
         acbu_client.burn(&user, &acbu_amount);
 
-        let currencies: Vec<CurrencyCode> = env.invoke_contract(
-            &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_CURRENCIES),
-            vec![&env],
-        );
-
-        if currencies.is_empty() {
-            env.panic_with_error(ContractError::InvalidCurrency);
-        }
-
-        let currencies: Vec<CurrencyCode> = env.invoke_contract(&oracle_addr, &Symbol::new(&env, ORACLE_GET_CURRENCIES), vec![&env]);
-        
         let mut amounts_out = Vec::new(&env);
+        let mut allocated_gross = 0i128;
+        let mut allocated_fee = 0i128;
+        let last_positive_weight_index = last_positive_weight_index.unwrap();
+
         for i in 0..currencies.len() {
             let currency = currencies.get(i).unwrap();
             let recipient = recipients.get(i).unwrap();
+            let weight = weights.get(i).unwrap();
 
-            let weight: i128 = env.invoke_contract(&oracle_addr, &Symbol::new(&env, ORACLE_GET_BASKET_WEIGHT), vec![&env, currency.clone().into_val(&env)]);
-            let rate: i128 = env.invoke_contract(&oracle_addr, &Symbol::new(&env, ORACLE_GET_RATE), vec![&env, currency.clone().into_val(&env)]);
-            let stoken: Address = env.invoke_contract(&oracle_addr, &Symbol::new(&env, ORACLE_GET_S_TOKEN_ADDR), vec![&env, currency.clone().into_val(&env)]);
-
-
-            // C-057: Each currency slot maps to the corresponding recipient by index.
-            if i >= recipients.len() {
-                env.panic_with_error(ContractError::InvalidRecipient);
-            }
-            let recipient = recipients.get(i).unwrap();
-
-            let weight: i128 = env.invoke_contract(
-                &oracle_addr,
-                &Symbol::new(&env, ORACLE_GET_BASKET_WEIGHT),
-                vec![&env, currency.clone().into_val(&env)],
-            );
             if weight == 0 {
                 amounts_out.push_back(0);
                 continue;
             }
 
-            let rate: i128 = env.invoke_contract(
+            let (acbu_gross_i, fee_i) = if i == last_positive_weight_index {
+                (
+                    acbu_amount
+                        .checked_sub(allocated_gross)
+                        .expect("Underflow in remaining gross allocation"),
+                    total_fee
+                        .checked_sub(allocated_fee)
+                        .expect("Underflow in remaining fee allocation"),
+                )
+            } else {
+                (
+                    Self::weighted_floor(acbu_amount, weight, total_weight),
+                    Self::weighted_floor(total_fee, weight, total_weight),
+                )
+            };
+            let net_acbu_i = acbu_gross_i
+                .checked_sub(fee_i)
+                .expect("Underflow in net basket allocation");
+            allocated_gross = allocated_gross
+                .checked_add(acbu_gross_i)
+                .expect("Overflow in gross allocation");
+            allocated_fee = allocated_fee
+                .checked_add(fee_i)
+                .expect("Overflow in fee allocation");
+
+            let (rate, rate_timestamp): (i128, u64) = env.invoke_contract(
                 &oracle_addr,
-                &Symbol::new(&env, ORACLE_GET_RATE),
+                &Symbol::new(&env, ORACLE_GET_RATE_WITH_TS),
                 vec![&env, currency.clone().into_val(&env)],
             );
-            if rate == 0 {
+            if current_time > rate_timestamp.saturating_add(UPDATE_INTERVAL_SECONDS) {
+                env.panic_with_error(ContractError::OracleError);
+            }
+            if rate <= 0 {
                 env.panic_with_error(ContractError::InvalidRate);
             }
 
@@ -358,36 +347,25 @@ impl BurningContract {
                 &Symbol::new(&env, ORACLE_GET_S_TOKEN_ADDR),
                 vec![&env, currency.clone().into_val(&env)],
             );
-
-            // Per-currency gross ACBU slice and fee slice.
-            let acbu_gross_i = (weight * acbu_amount) / BASIS_POINTS;
-            let fee_i = (weight * total_fee) / BASIS_POINTS;
-            let _net_acbu_i = acbu_gross_i - fee_i;
-            let usd_i = (weight * usd_total) / BASIS_POINTS;
-            // native_i = (usd_i * DECIMALS) / rate — correct because usd_total was already
-            // divided by DECIMALS, so multiplying back restores the fixed-point scaling.
-            let native_i = usd_i
-                .checked_mul(DECIMALS)
+            let native_i = net_acbu_i
+                .checked_mul(acbu_rate)
                 .and_then(|v| v.checked_div(rate))
-                .expect("Overflow in native_i calculation");
+                .expect("Overflow in native basket calculation");
 
             if native_i > 0 {
                 let token = soroban_sdk::token::Client::new(&env, &stoken);
-                token.transfer_from(&env.current_contract_address(), &vault, &recipient, &native_i);
                 let spender = env.current_contract_address();
                 token.transfer_from(&spender, &vault, &recipient, &native_i);
             }
             amounts_out.push_back(native_i);
-        }
 
-            let tx_id = SorobanString::from_str(&env, "redeem_basket");
             let burn_event = BurnEvent {
-                transaction_id: tx_id,
+                transaction_id: SorobanString::from_str(&env, "redeem_basket"),
                 user: user.clone(),
                 acbu_amount: acbu_gross_i,
                 net_acbu: net_acbu_i,
                 local_amount: native_i,
-                currency: currency.clone(),
+                currency,
                 fee: fee_i,
                 rate,
                 timestamp: env.ledger().timestamp(),
@@ -396,23 +374,20 @@ impl BurningContract {
                 .publish((symbol_short!("burn"), user.clone()), burn_event);
         }
 
-        // Release re-entrancy guard
-        reentrancy_guard::release_guard(&env);
+        if allocated_gross != acbu_amount || allocated_fee != total_fee {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        if allocated_gross
+            .checked_sub(allocated_fee)
+            .expect("Underflow in allocated net validation")
+            != net_acbu
+        {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
 
+        reentrancy_guard::release_guard(&env);
         amounts_out
     }
-
-    fn check_paused(env: &Env) {
-        if env.storage().instance().get::<_, bool>(&DATA_KEY.paused).unwrap_or(false) {
-            env.panic_with_error(ContractError::Paused);
-        }
-    }
-
-    fn check_admin(env: &Env) {
-        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
-        admin.require_auth();
-    }
-}
 
     pub fn version(env: Env) -> u32 {
         env.storage()
@@ -422,8 +397,7 @@ impl BurningContract {
     }
 
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
-        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
-        admin.require_auth();
+        Self::check_admin(&env);
 
         let current_version = Self::version(env.clone());
         if new_version <= current_version {
@@ -433,15 +407,50 @@ impl BurningContract {
         env.deployer().update_current_contract_wasm(new_wasm_hash);
 
         for v in current_version..new_version {
-            match v {
-                0 => migrate_v0_to_v1(env.clone()),
-                _ => {}
+            if v == 0 {
+                migrate_v0_to_v1(env.clone());
             }
         }
 
         env.storage()
             .instance()
             .set(&SharedDataKey::Version, &new_version);
+    }
+
+    fn weighted_floor(total: i128, weight: i128, total_weight: i128) -> i128 {
+        total
+            .checked_mul(weight)
+            .and_then(|v| v.checked_div(total_weight))
+            .expect("Overflow in weighted allocation")
+    }
+
+    fn check_reserves(env: &Env, acbu_token: &Address, reserve_tracker_addr: &Address) {
+        let current_supply: i128 =
+            env.invoke_contract(acbu_token, &Symbol::new(env, "get_total_supply"), vec![env]);
+        let reserve_ok: bool = env.invoke_contract(
+            reserve_tracker_addr,
+            &Symbol::new(env, "is_reserve_sufficient"),
+            vec![env, current_supply.into_val(env)],
+        );
+        if !reserve_ok {
+            env.panic_with_error(ContractError::InsufficientReserves);
+        }
+    }
+
+    fn check_paused(env: &Env) {
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&DATA_KEY.paused)
+            .unwrap_or(false)
+        {
+            env.panic_with_error(ContractError::Paused);
+        }
+    }
+
+    fn check_admin(env: &Env) {
+        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
+        admin.require_auth();
     }
 }
 

--- a/acbu_burning/tests/redeem_basket.rs
+++ b/acbu_burning/tests/redeem_basket.rs
@@ -64,6 +64,69 @@ fn test_redeem_basket_success() {
 }
 
 #[test]
+fn test_redeem_basket_allocates_weighted_remainder() {
+    let env = Env::default();
+    let ctx = setup_test(&env);
+
+    let c1 = CurrencyCode::new(&env, "NGN");
+    let c2 = CurrencyCode::new(&env, "KES");
+    let c3 = CurrencyCode::new(&env, "RWF");
+    let currs = vec![&env, c1.clone(), c2.clone(), c3.clone()];
+    ctx.oracle.set_currencies(&currs);
+
+    let (st1_id, st1, st1_sac) = create_stoken(&env, &ctx.admin);
+    let (st2_id, st2, st2_sac) = create_stoken(&env, &ctx.admin);
+    let (st3_id, st3, st3_sac) = create_stoken(&env, &ctx.admin);
+    ctx.oracle.set_stoken(&c1, &st1_id);
+    ctx.oracle.set_stoken(&c2, &st2_id);
+    ctx.oracle.set_stoken(&c3, &st3_id);
+
+    let mut weights = Map::new(&env);
+    weights.set(c1.clone(), 3333);
+    weights.set(c2.clone(), 3333);
+    weights.set(c3.clone(), 3334);
+    ctx.oracle.set_weights(&weights);
+
+    let burn_amount: i128 = (10 * DECIMALS) + 1;
+    ctx.acbu_token.mint(&ctx.user, &burn_amount);
+
+    let vault_amount: i128 = 500 * DECIMALS;
+    st1_sac.mint(&ctx.vault, &vault_amount);
+    st1.approve(&ctx.vault, &ctx.burning_id, &vault_amount, &200u32);
+    st2_sac.mint(&ctx.vault, &vault_amount);
+    st2.approve(&ctx.vault, &ctx.burning_id, &vault_amount, &200u32);
+    st3_sac.mint(&ctx.vault, &vault_amount);
+    st3.approve(&ctx.vault, &ctx.burning_id, &vault_amount, &200u32);
+
+    let ts = env.ledger().timestamp();
+    ctx.oracle.set_acbu_rate(&DECIMALS, &ts);
+    ctx.oracle.set_currency_rate(&c1, &DECIMALS);
+    ctx.oracle.set_currency_rate(&c2, &DECIMALS);
+    ctx.oracle.set_currency_rate(&c3, &DECIMALS);
+    ctx.oracle.set_timestamp(&c1, &ts);
+    ctx.oracle.set_timestamp(&c2, &ts);
+    ctx.oracle.set_timestamp(&c3, &ts);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    let recipients = vec![&env, r1.clone(), r2.clone(), r3.clone()];
+
+    let amounts = ctx
+        .burning
+        .redeem_basket(&ctx.user, &recipients, &burn_amount);
+
+    let expected_fee = (burn_amount * 100) / BASIS_POINTS;
+    let expected_net = burn_amount - expected_fee;
+    let total_out = amounts.get(0).unwrap() + amounts.get(1).unwrap() + amounts.get(2).unwrap();
+
+    assert_eq!(total_out, expected_net);
+    assert_eq!(st1.balance(&r1), amounts.get(0).unwrap());
+    assert_eq!(st2.balance(&r2), amounts.get(1).unwrap());
+    assert_eq!(st3.balance(&r3), amounts.get(2).unwrap());
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #11)")] // InvalidRecipient
 fn test_redeem_basket_duplicate_recipients() {
     let env = Env::default();


### PR DESCRIPTION
Closes #201 

# PR Description

Fixes #201 by removing silent dust loss in basket redemption when weighted integer division truncates per-recipient allocations. The burn flow now partitions the gross ACBU amount and fee by basket weight, assigns any remainder to the last positive-weight basket leg, and validates that the final allocated gross, fee, and net totals match the original burn inputs. This keeps the basket redemption deterministic with Soroban `i128` token amounts and ensures no net ACBU dust is left unaccounted for.

# Changed

- Fixes #201 by allocating basket redemption remainder instead of dropping truncated dust.
- Fixes #201 by validating per-leg gross, fee, and net allocation totals before completing redemption.
- Added a regression test for uneven basket weights that previously lost one unit through truncation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for burn operations with explicit minimum amount checks.
  * Enhanced oracle rate freshness validation.
  * Added consistency checks for reserve health and allocation integrity.

* **New Features**
  * Updated weighted allocation logic for basket redemptions.

* **Tests**
  * Added test coverage for weighted basket redemption with remainder allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->