### PR TITLE
perf(shared): store CurrencyCode as a single String, not Vec<String>

### DIFF
--- a/README_REPO.md
+++ b/README_REPO.md
@@ -106,7 +106,7 @@ The file includes:
   - `MultisigConfig`
   - Event types for proposal creation/approval/execution.
 - **Financial types**:
-  - `CurrencyCode` (a wrapper around Soroban `Vec<SorobanString>`)
+  - `CurrencyCode` (a wrapper around a single Soroban `String`)
   - `RateData`
   - `ReserveData`
   - `AccountDetails` (bank/account details for withdrawals)

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -80,16 +80,25 @@ pub struct ProposalExecutedEvent {
 
 pub const CONTRACT_VERSION: u32 = 1;
 
-/// Currency code type (e.g., "NGN", "KES", "RWF")
+/// Currency code type (e.g., "NGN", "KES", "RWF").
+///
+/// A currency code is logically a single short string. It is stored as one
+/// [`SorobanString`] rather than a `Vec<SorobanString>` so that constructing,
+/// cloning, comparing, and using it as a `Map` key does not allocate a
+/// temporary host `Vec` object per call — which previously inflated both gas
+/// usage and compiled WASM size.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CurrencyCode(pub Vec<SorobanString>);
+pub struct CurrencyCode(pub SorobanString);
 
 impl CurrencyCode {
     pub fn new(env: &soroban_sdk::Env, code: &str) -> Self {
-        let mut v = Vec::new(env);
-        v.push_back(SorobanString::from_str(env, code));
-        CurrencyCode(v)
+        CurrencyCode(SorobanString::from_str(env, code))
+    }
+
+    /// Borrow the underlying currency code string (e.g. `"NGN"`).
+    pub fn code(&self) -> &SorobanString {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Here's a summary of the contribution.
Closes #254 

What the issue was
[shared/src/lib.rs:86](vscode-webview://1pfv0gu1r2g3aiop6umibm6308ad1k7tj501ohmp4dnpejr9iq8u/shared/src/lib.rs#L86) defined CurrencyCode(pub Vec<SorobanString>), but a currency code is logically a single string like "NGN". Wrapping it in a Vec:

Allocated a temporary host Vec and push_back'd into it on every CurrencyCode::new() call.
Paid Vec host-object cost on every clone, Eq/PartialEq comparison, and Map<CurrencyCode, …> key lookup — and these maps are hit constantly in the oracle (get_rate, get_basket_weight, get_acbu_usd_rate, etc.).
Inflated compiled WASM size and gas.
The fix
Changed the inner representation to a single SorobanString:


pub struct CurrencyCode(pub SorobanString);
The public CurrencyCode::new(env, code) signature is unchanged, so it's non-breaking at the API level — all contracts and tests construct via new() and never touched .0 directly (verified across the whole workspace). I also added a code() accessor and updated the doc comment plus the README_REPO.md line that described it as a Vec<SorobanString> wrapper.

Verification
Confirmed via grep that the only code constructing CurrencyCode from the tuple form was lib.rs itself; every other crate/test uses ::new(). All other .0 accesses in the repo are on env.events() tuples, unrelated.
Lending pool / savings vault don't use the type at all.
Couldn't run cargo build/cargo test — Rust/cargo isn't installed in this environment. Verification was static (grep + diff review). A maintainer should run cargo test before merge.

One thing to flag for review
This changes the XDR layout of CurrencyCode (Vec → String). For a fresh deployment that's fine, but any already-persisted CurrencyCode values in contract storage (rate maps, reserve maps, s-token maps) would not deserialize under the new layout. Worth calling out in the PR so maintainers can confirm there's no live state to migrate. Committed on branch CurrencyCode-stored-as-Vec-during-iteration —

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guide reflecting CurrencyCode implementation changes.

* **Refactor**
  * Optimized CurrencyCode storage structure for improved efficiency.
  * Added new accessor method for retrieving currency code values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->