### PR TITLE
feat(contracts): embed ABI version via contractmeta for forward compatibility

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env, IntoVal,
-    String as SorobanString, Symbol, Vec,
+    contract, contractimpl, contractmeta, contracttype, symbol_short, vec, Address, BytesN, Env,
+    IntoVal, String as SorobanString, Symbol, Vec,
 };
 
 use shared::{
@@ -57,6 +57,8 @@ const DATA_KEY: DataKey = DataKey {
 };
 
 // CONTRACT_VERSION is imported from shared
+
+contractmeta!(key = "version", val = "1");
 
 #[contract]
 pub struct BurningContract;

--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Symbol,
 };
 
 use shared::{DataKey as SharedDataKey, CONTRACT_VERSION, reentrancy_guard};
@@ -82,6 +83,8 @@ pub struct EscrowRefundedEvent {
     pub amount: i128,
     pub timestamp: u64,
 }
+
+contractmeta!(key = "version", val = "1");
 
 #[contract]
 pub struct Escrow;

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Symbol,
 };
 
 use shared::{DataKey as SharedDataKey, BASIS_POINTS, CONTRACT_VERSION, reentrancy_guard};
@@ -114,6 +115,8 @@ pub enum Error {
     NoPendingUpgrade = 2004,
     Unknown = 2999,
 }
+
+contractmeta!(key = "version", val = "1");
 
 #[contract]
 pub struct LendingPool;

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -7,8 +7,8 @@ fn generate_unique_tx_id(env: &Env, _user: &Address, _amount: i128, prefix: &str
 #![no_std]
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Bytes, BytesN,
-    Env, IntoVal, String as SorobanString, Symbol,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, vec, Address,
+    Bytes, BytesN, Env, IntoVal, String as SorobanString, Symbol,
 };
 
 use shared::{
@@ -88,6 +88,8 @@ const TX_NONCE_KEY: Symbol = symbol_short!("TX_NONCE");
 const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
 
 // CONTRACT_VERSION is imported from shared
+
+contractmeta!(key = "version", val = "1");
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/acbu_multisig/src/lib.rs
+++ b/acbu_multisig/src/lib.rs
@@ -30,7 +30,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contractimpl, contractmeta, contracttype, symbol_short, Address, BytesN, Env,
     String as SorobanString, Vec,
 };
 
@@ -94,6 +94,8 @@ pub enum Error {
 // ---------------------------------------------------------------------------
 // Contract
 // ---------------------------------------------------------------------------
+
+contractmeta!(key = "version", val = "1");
 
 #[contract]
 pub struct MultisigContract;

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Map, Symbol, Vec,
 };
 
 use shared::{
@@ -142,6 +142,8 @@ pub struct ValidatorSignature {
     pub validator: Address,
     pub timestamp: u64,
 }
+
+contractmeta!(key = "version", val = "9");
 
 #[contract]
 pub struct OracleContract;

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Map, Symbol, Vec,
 };
 
 use shared::{CurrencyCode, DataKey as SharedDataKey, ReserveData, BASIS_POINTS, CONTRACT_VERSION};
@@ -50,6 +50,8 @@ const DATA_KEY: DataKey = DataKey {
 /// claiming ownership, giving the current admin a window to cancel a mistaken
 /// or malicious transfer.
 const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
+
+contractmeta!(key = "version", val = "1");
 
 #[contract]
 pub struct ReserveTrackerContract;

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Symbol, Vec,
 };
 
 use shared::{calculate_fee, DataKey as SharedDataKey, reentrancy_guard, BASIS_POINTS, CONTRACT_VERSION};
@@ -12,8 +12,8 @@ mod shared {
 
 // --- Definitions (These were missing, now included here) ---
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    BytesN, Env, Symbol, Vec,
 };
 
 use shared::{calculate_fee, DataKey as SharedDataKey, reentrancy_guard, BASIS_POINTS, CONTRACT_VERSION};
@@ -119,6 +119,8 @@ pub struct WithdrawEvent {
 // ---------------------------------------------------------------------------
 // Contract
 // ---------------------------------------------------------------------------
+contractmeta!(key = "version", val = "1");
+
 #[contract]
 pub struct SavingsVault;
 


### PR DESCRIPTION
Closes #334 

Soroban SDK v21.7.7 does not have a #[contractversion] proc macro. The SDK delegates version tracking entirely to the contract developer via manual storage.

The contractmeta macro (built into soroban-sdk since at least v21) embeds key-value metadata into the WASM binary's custom contractmetav0 section. This metadata is inspectable offline via "stellar contract inspect" -- no on-chain execution required.

Each contract now emits contractmeta(key = "version", val = "N") where N matches the existing CONTRACT_VERSION constant. The existing runtime version storage and migration functions remain in place for on-chain upgrade logic. This gives two complementary versioning layers -- compile-time WASM metadata for offline ABI inspection, and runtime storage for migration gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added version metadata to all contract deployments for improved tracking and transparency on-chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->