### PR TITLE
fix(lending-pool): restrict set_interest_rate to admin only (#339)

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -112,6 +112,9 @@ pub enum Error {
     InvalidVersion = 2002,
     TimelockNotElapsed = 2003,
     NoPendingUpgrade = 2004,
+    NoPendingAdmin = 2005,
+    AdminTimelockNotElapsed = 2006,
+    NoPendingAdminToCancel = 2007,
     Unknown = 2999,
 }
 
@@ -548,6 +551,47 @@ impl LendingPool {
             .persistent()
             .get(&DataKey::Balance(lender))
             .unwrap_or(0)
+    }
+
+    /// Returns the current annualized loan interest rate in basis points.
+    pub fn get_interest_rate(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::FeeRate)
+            .unwrap_or(0)
+    }
+
+    /// Update the annualized loan interest rate in basis points.
+    ///
+    /// This is a high-privilege operation — changing the interest rate affects
+    /// all lenders and borrowers. Access is therefore restricted to the **admin**
+    /// only. Operators (who handle day-to-day minting) must NOT be able to call
+    /// this function; a compromised operator key must not be able to set
+    /// exorbitant rates. See issue #339.
+    pub fn set_interest_rate(env: Env, new_rate_bps: i128) {
+        // Admin-only: explicitly fetches and requires auth from the stored admin
+        // address. This is identical to check_admin but inlined here to make the
+        // privilege boundary visible at the call site.
+        Self::check_admin(&env);
+
+        if new_rate_bps < 0 || new_rate_bps > BASIS_POINTS {
+            env.panic_with_error(Error::InvalidAmount);
+        }
+
+        let old_rate: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeRate)
+            .unwrap_or(0);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRate, &new_rate_bps);
+
+        env.events().publish(
+            (symbol_short!("rate_set"),),
+            (old_rate, new_rate_bps),
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Interest rate changes affect all lenders and borrowers. A compromised operator key must not be able to set exorbitant rates.

Changes:
- Add set_interest_rate(env, new_rate_bps) as an admin-only function gated by check_admin(). Only the stored admin address can authorize a rate change; the operator role has no access.
- Add get_interest_rate(env) getter for completeness.
- Add missing Error variants NoPendingAdmin, AdminTimelockNotElapsed, and NoPendingAdminToCancel that were already referenced in accept_admin / cancel_admin_transfer but absent from the enum.
- Emit a rate_set event logging the old and new rate for auditability.

Closes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interest rate query and update capabilities with admin authorization and validation.
  * Interest rate changes emit confirmation events.
  
* **Improvements**
  * Enhanced error handling for admin rotation flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->