### PR TITLE
fix(setup): automate git hooks configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ After deployment, contract addresses are saved to `.soroban/deployment_{network}
 
 ## Development
 
+### Git Hooks Setup
+
+After cloning, run:
+```bash
+./scripts/setup-git-hooks.sh
+```
+This configures the pre-commit hook for WASM integrity checks.
+
+
 ### Project Structure
 
 ```

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Setup git hooks for this project
+
+set -e
+
+echo "🔧 Setting up git hooks..."
+
+git config core.hooksPath .githooks
+
+chmod +x .githooks/*
+
+echo "✅ Git hooks configured successfully!"
+echo "   core.hooksPath = $(git config core.hooksPath)"


### PR DESCRIPTION
Closes #393

- Added `scripts/setup-git-hooks.sh` for automatic `core.hooksPath` setup
- Updated `SETUP_HOOKS.md` with recommended one-command setup
- Added Git Hooks section to root README.md

New developers can now simply run `./scripts/setup-git-hooks.sh` after cloning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Git Hooks Setup" subsection with instructions for running the setup script after cloning the repository. Explains how pre-commit hooks will validate WASM integrity automatically.

* **Chores**
  * Added setup script that configures git hooks for automatic WASM integrity validation in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->