### PR TITLE
fix: resolve lending pool over-borrowing (#314) and minting overflow (#304) with cleanup

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -13,6 +13,7 @@ pub enum DataKey {
     FeeRate,
     Paused,
     Balance(Address),
+    Borrowed(Address), // Tracks total amount borrowed from each lender
     Loan(LoanId),
     ActiveLoansLiquidity, // Tracks total amount currently loaned out
     LenderBalances,
@@ -38,6 +39,7 @@ pub struct LoanId(pub Address, pub u64);
 #[derive(Clone, Debug)]
 pub struct LoanData {
     pub borrower: Address,
+    pub lender: Address,
     pub amount: i128,
     pub collateral_amount: i128,
     pub interest_rate_bps: u32,
@@ -112,6 +114,9 @@ pub enum Error {
     InvalidVersion = 2002,
     TimelockNotElapsed = 2003,
     NoPendingUpgrade = 2004,
+    NoPendingAdmin = 2005,
+    AdminTimelockNotElapsed = 2006,
+    NoPendingAdminToCancel = 2007,
     Unknown = 2999,
 }
 
@@ -197,26 +202,17 @@ impl LendingPool {
             .persistent()
             .get(&DataKey::Balance(lender.clone()))
             .unwrap_or(0);
-        if current_balance < amount {
+        
+        let already_borrowed: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Borrowed(lender.clone()))
+            .unwrap_or(0);
+            
+        let available_balance = current_balance.checked_sub(already_borrowed).unwrap_or(0);
+        if available_balance < amount {
             env.panic_with_error(Error::InsufficientBalance);
         }
-
-        // Available liquid reserves check
-        let active_loans_liquidity: i128 = env.storage().instance().get(&DataKey::ActiveLoansLiquidity).unwrap_or(0);
-        
-        let acbu_token: Address = env.storage().instance().get(&DataKey::AcbuToken).unwrap();
-        let token = soroban_sdk::token::Client::new(&env, &acbu_token);
-        let contract_balance = token.balance(&env.current_contract_address());
-
-        // ensure we don't withdraw collateral or loaned out funds
-        // The contract balance must remain at least active_loans_liquidity
-        // (plus any locked collateral, but locked collateral isn't part of withdrawable liquidity anyway)
-        // Wait, available liquidity = contract_balance - active_loans_liquidity
-        // No, available_liquidity = total_deposits - active_loans_liquidity.
-        // It's safer to just check available liquidity.
-        // Let's assume the contract balance tracks all deposited + collateral.
-        // If we just check `contract_balance - active_loans_liquidity`, we might accidentally let them withdraw collateral.
-        // To be perfectly safe, we should track total_deposits explicitly, or just ensure `amount <= total_deposits - active_loans_liquidity`.
 
         // CEI: Update state before external calls
         let new_balance = current_balance
@@ -226,6 +222,8 @@ impl LendingPool {
             .persistent()
             .set(&DataKey::Balance(lender.clone()), &new_balance);
 
+        let acbu_token: Address = env.storage().instance().get(&DataKey::AcbuToken).unwrap();
+        let token = soroban_sdk::token::Client::new(&env, &acbu_token);
         token.transfer(&env.current_contract_address(), &lender, &amount);
 
         env.events()
@@ -238,6 +236,7 @@ impl LendingPool {
     pub fn borrow(
         env: Env,
         borrower: Address,
+        lender: Address,
         amount: i128,
         collateral_amount: i128,
         loan_id: u64,
@@ -257,6 +256,21 @@ impl LendingPool {
             env.panic_with_error(Error::InsufficientCollateral);
         }
 
+        let lender_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(lender.clone()))
+            .unwrap_or(0);
+        let already_borrowed: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Borrowed(lender.clone()))
+            .unwrap_or(0);
+        let unborrowed_balance = lender_balance.checked_sub(already_borrowed).unwrap_or(0);
+        if unborrowed_balance < amount {
+            env.panic_with_error(Error::InsufficientBalance);
+        }
+
         let loan_key = LoanId(borrower.clone(), loan_id);
         if env.storage().persistent().has(&DataKey::Loan(loan_key.clone())) {
             env.panic_with_error(Error::InvalidState);
@@ -274,6 +288,13 @@ impl LendingPool {
         let active_loans_liquidity: i128 = env.storage().instance().get(&DataKey::ActiveLoansLiquidity).unwrap_or(0);
         env.storage().instance().set(&DataKey::ActiveLoansLiquidity, &(active_loans_liquidity + amount));
 
+        let new_borrowed = already_borrowed
+            .checked_add(amount)
+            .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Borrowed(lender.clone()), &new_borrowed);
+
         // Pull collateral in BEFORE paying out the loan principal.
         token.transfer(&borrower, &env.current_contract_address(), &collateral_amount);
         token.transfer(&env.current_contract_address(), &borrower, &amount);
@@ -283,6 +304,7 @@ impl LendingPool {
         
         let loan_data = LoanData {
             borrower: borrower.clone(),
+            lender: lender.clone(),
             amount,
             collateral_amount,
             interest_rate_bps: fee_rate_bps as u32,
@@ -317,7 +339,7 @@ impl LendingPool {
             (symbol_short!("loan_cr"),),
             LoanCreatedEvent {
                 loan_id,
-                lender: env.current_contract_address(),
+                lender,
                 borrower,
                 amount,
                 interest_bps: fee_rate,
@@ -388,6 +410,19 @@ impl LendingPool {
 
         let active_loans_liquidity: i128 = env.storage().instance().get(&DataKey::ActiveLoansLiquidity).unwrap_or(0);
         env.storage().instance().set(&DataKey::ActiveLoansLiquidity, &active_loans_liquidity.checked_sub(principal_repaid).unwrap_or(0));
+
+        if principal_repaid > 0 {
+            let lender = loan_data.lender.clone();
+            let already_borrowed: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Borrowed(lender.clone()))
+                .unwrap_or(0);
+            let new_borrowed = already_borrowed.checked_sub(principal_repaid).unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Borrowed(lender), &new_borrowed);
+        }
 
         token.transfer(&borrower, &env.current_contract_address(), &amount);
 

--- a/acbu_lending_pool/tests/test.rs
+++ b/acbu_lending_pool/tests/test.rs
@@ -201,7 +201,7 @@ fn test_borrow_basic() {
     token_admin.mint(&borrower, &collateral);
 
     // (contract transfers ACBU *out* to borrower; collateral is recorded but not transferred in MVP)
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     // Loan is recorded with correct fields
     let loan = client
@@ -250,7 +250,7 @@ fn test_fee_rate_accrues_into_repayment_due() {
     token_admin.mint(&borrower, &(collateral + borrow_amount));
 
     let loan_id = 226u64;
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     let elapsed = 365u64 * 24 * 60 * 60 / 2;
     env.ledger().with_mut(|l| l.timestamp += elapsed);
@@ -292,7 +292,7 @@ fn test_repay_basic() {
     let borrower = Address::generate(&env);
     let borrow_amount: i128 = 300_000;
     let loan_id: u64 = 7;
-    client.borrow(&borrower, &borrow_amount, &0, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &0, &loan_id);
 
     // Borrower now holds borrow_amount tokens; repay the full amount
     client.repay(&borrower, &borrow_amount, &loan_id);
@@ -336,7 +336,7 @@ fn test_borrow_exceeds_liquidity_fails() {
     // Attempt to borrow more than what is in the pool
     let borrower = Address::generate(&env);
     let over_amount: i128 = small_liquidity + 1;
-    let result = client.try_borrow(&borrower, &over_amount, &0, &1u64);
+    let result = client.try_borrow(&borrower, &lender, &over_amount, &0, &1u64);
 
     assert!(
         result.is_err(),
@@ -369,7 +369,7 @@ fn test_repay_wrong_loan_id_fails() {
     let borrower = Address::generate(&env);
     let borrow_amount: i128 = 100_000;
     let real_loan_id: u64 = 42;
-    client.borrow(&borrower, &borrow_amount, &0, &real_loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &0, &real_loan_id);
 
     // Attempt to repay using a different loan_id
     let wrong_loan_id: u64 = 99;
@@ -413,7 +413,7 @@ fn test_loan_default_scenario() {
     let borrower = Address::generate(&env);
     let borrow_amount: i128 = 200_000;
     let loan_id: u64 = 55;
-    client.borrow(&borrower, &borrow_amount, &0, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &0, &loan_id);
 
     // Borrower never repays — loan remains open.
     // No liquidation function exists yet; assert the loan is still present and overdue.
@@ -462,7 +462,7 @@ fn test_borrow_repay_full_lifecycle() {
     let borrower = Address::generate(&env);
     let borrow_amount: i128 = 600_000;
     let loan_id: u64 = 100;
-    client.borrow(&borrower, &borrow_amount, &0, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &0, &loan_id);
 
     assert_eq!(token_client.balance(&borrower), borrow_amount);
     assert_eq!(
@@ -527,7 +527,7 @@ fn test_loan_lifecycle_emits_events() {
     let borrow_amount = 300_000i128;
 
     // 1. Borrow - verify state transition + event
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     // Assert loan state created
     let loan = client.get_loan(&borrower, &loan_id).unwrap();

--- a/acbu_lending_pool/tests/test_comprehensive.rs
+++ b/acbu_lending_pool/tests/test_comprehensive.rs
@@ -167,7 +167,7 @@ fn test_borrow_creates_loan() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     let loan = client.get_loan(&borrower, &loan_id).expect("loan should exist");
     assert_eq!(loan.amount, borrow_amount);
@@ -191,7 +191,7 @@ fn test_borrow_transfers_tokens_to_borrower() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &1u64);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &1u64);
 
     assert_eq!(token_client.balance(&borrower), borrow_amount);
 }
@@ -210,7 +210,7 @@ fn test_borrow_exceeds_pool_liquidity_fails() {
 
     client.deposit(&lender, &pool_liquidity);
 
-    let result = client.try_borrow(&borrower, &borrow_amount, &0, &1u64);
+    let result = client.try_borrow(&borrower, &lender, &borrow_amount, &0, &1u64);
     assert!(result.is_err());
 }
 
@@ -219,7 +219,8 @@ fn test_borrow_zero_amount_fails() {
     let (env, client, _contract_id, _admin, _acbu_token) = setup();
 
     let borrower = Address::generate(&env);
-    let result = client.try_borrow(&borrower, &0, &0, &1u64);
+    let lender = Address::generate(&env);
+    let result = client.try_borrow(&borrower, &lender, &0, &0, &1u64);
 
     assert!(result.is_err());
 }
@@ -240,9 +241,9 @@ fn test_borrow_duplicate_loan_id_fails() {
     token_admin.mint(&borrower, &(collateral * 2));
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
-    let result = client.try_borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    let result = client.try_borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     assert!(result.is_err());
 }
 
@@ -262,7 +263,7 @@ fn test_borrow_emits_event() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     let events = env.events().all();
     let borrow_event = events
@@ -309,7 +310,7 @@ fn test_repay_partial_reduces_loan_amount() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     client.repay(&borrower, &repay_amount, &loan_id);
 
     let loan = client.get_loan(&borrower, &loan_id).expect("loan should still exist");
@@ -332,7 +333,7 @@ fn test_repay_full_removes_loan() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     client.repay(&borrower, &borrow_amount, &loan_id);
 
     assert!(client.get_loan(&borrower, &loan_id).is_none());
@@ -357,7 +358,7 @@ fn test_repay_full_returns_collateral() {
     client.deposit(&lender, &pool_liquidity);
     
     let borrower_balance_before = token_client.balance(&borrower);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     
     // After borrow: borrower has borrow_amount (collateral was transferred to contract)
     assert_eq!(token_client.balance(&borrower), borrow_amount);
@@ -384,7 +385,7 @@ fn test_repay_more_than_loan_amount_fails() {
     token_admin.mint(&borrower, &(collateral + borrow_amount));
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     let result = client.try_repay(&borrower, &(borrow_amount + 1), &loan_id);
     assert!(result.is_err());
@@ -416,7 +417,7 @@ fn test_repay_zero_amount_fails() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     let result = client.try_repay(&borrower, &0, &loan_id);
     assert!(result.is_err());
@@ -439,7 +440,7 @@ fn test_repay_emits_event() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     client.repay(&borrower, &repay_amount, &loan_id);
 
     let events = env.events().all();
@@ -506,7 +507,8 @@ fn test_borrow_when_paused_fails() {
     client.pause();
 
     let borrower = Address::generate(&env);
-    let result = client.try_borrow(&borrower, &1000, &0, &1u64);
+    let lender = Address::generate(&env);
+    let result = client.try_borrow(&borrower, &lender, &1000, &0, &1u64);
 
     assert!(result.is_err());
 }
@@ -527,7 +529,7 @@ fn test_repay_when_paused_fails() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     
     client.pause();
 
@@ -573,7 +575,7 @@ fn test_borrow_insufficient_collateral_fails() {
 
     client.deposit(&lender, &pool_liquidity);
 
-    let result = client.try_borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    let result = client.try_borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     assert!(result.is_err());
 }
 
@@ -597,9 +599,9 @@ fn test_multiple_borrowers_same_lender() {
     client.deposit(&lender, &pool_liquidity);
 
     // First borrower
-    client.borrow(&borrower1, &borrow_amount, &collateral, &1u64);
+    client.borrow(&borrower1, &lender, &borrow_amount, &collateral, &1u64);
     // Second borrower
-    client.borrow(&borrower2, &borrow_amount, &collateral, &2u64);
+    client.borrow(&borrower2, &lender, &borrow_amount, &collateral, &2u64);
 
     // Both loans should exist
     let loan1 = client.get_loan(&borrower1, &1u64).expect("loan1 should exist");
@@ -657,7 +659,7 @@ fn test_repay_interest_accrual() {
     token_admin.mint(&borrower, &collateral);
 
     client.deposit(&lender, &pool_liquidity);
-    client.borrow(&borrower, &borrow_amount, &collateral, &loan_id);
+    client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
 
     // Advance time to accrue interest
     env.ledger().set_timestamp(env.ledger().timestamp() + 30 * 24 * 60 * 60);
@@ -683,6 +685,6 @@ fn test_borrow_negative_collateral_fails() {
 
     client.deposit(&lender, &pool_liquidity);
 
-    let result = client.try_borrow(&borrower, &borrow_amount, &-100, &1u64);
+    let result = client.try_borrow(&borrower, &lender, &borrow_amount, &-100, &1u64);
     assert!(result.is_err());
 }

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -1,10 +1,4 @@
 #![no_std]
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env,
-    IntoVal, String as SorobanString, Symbol,
-use soroban_sdk::{Address, Env, String};
-fn generate_unique_tx_id(env: &Env, _user: &Address, _amount: i128, prefix: &str) -> String {     String::from_str(env, prefix) }
-#![no_std]
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Bytes, BytesN,
@@ -111,6 +105,10 @@ pub enum MintingError {
     FintechTxIdTooLong = 5016,
     FintechTxIdInvalidChar = 5017,
     InvalidVersion = 5018,
+    MaxSupplyExceeded = 5019,
+    NoPendingAdmin = 5020,
+    AdminTimelockNotElapsed = 5021,
+    NoPendingAdminToCancel = 5022,
     Unknown = 5999,
 }
 
@@ -234,7 +232,7 @@ impl MintingContract {
         let acbu_amount = usdc_after_fee
             .checked_mul(DECIMALS)
             .and_then(|v| v.checked_div(acbu_rate))
-            .expect("Overflow in acbu amount calculation");
+            .unwrap_or_else(|| env.panic_with_error(MintingError::InvalidMintAmount));
 
         let projected_supply = total_supply
             .checked_add(acbu_amount)
@@ -933,143 +931,6 @@ impl MintingContract {
     /// General fiat mint: User/fintech provides fintech_tx_id; operator/backend signs.
     /// Validates that the request is not duplicated and that rate/reserve checks pass.
     /// This replaces the previous hardcoded 1:1 minting path with full oracle + reserve validation.
-    pub fn mint_from_fiat(
-        env: Env,
-        operator: Address,
-        recipient: Address,
-        currency: CurrencyCode,
-        fiat_amount: i128,
-        fintech_tx_id: SorobanString,
-    ) -> i128 {
-        Self::check_paused(&env);
-        let expected_operator: Address = Self::get_operator(env.clone());
-        if operator != expected_operator {
-            panic!("Unauthorized operator");
-        }
-        operator.require_auth();
-        // C-058: reject contract-type recipients — minting to a contract address
-        // that has no token-receipt logic would permanently strand the funds.
-        Self::assert_recipient_is_account(&recipient);
-        // Prevent self-minting: recipient cannot be the minter
-        if recipient == operator {
-            panic!("Recipient cannot be operator");
-        }
-
-        if fintech_tx_id.len() == 0 {
-            panic!("fintech_tx_id cannot be empty");
-        }
-
-        if !check_proof_unused(&env, &fintech_tx_id) {
-            panic!("Fiat transaction already processed");
-        }
-
-        let min_amount: i128 = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.min_mint_amount)
-            .unwrap();
-        let max_amount: i128 = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.max_mint_amount)
-            .unwrap();
-
-        let acbu_token: Address = env.storage().instance().get(&DATA_KEY.acbu_token).unwrap();
-        let oracle_addr: Address = env.storage().instance().get(&DATA_KEY.oracle).unwrap();
-        let reserve_tracker_addr: Address = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.reserve_tracker)
-            .unwrap();
-        let vault: Address = env.storage().instance().get(&DATA_KEY.vault).unwrap();
-        let fee_single: i128 = env.storage().instance().get(&DATA_KEY.fee_single).unwrap();
-        let mut total_supply: i128 = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.total_supply)
-            .unwrap_or(0);
-
-        let expected_stoken: Address = env.invoke_contract(
-            &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_S_TOKEN_ADDR),
-            vec![&env, currency.clone().into_val(&env)],
-        );
-
-        // Get ACBU rate with timestamp and validate oracle freshness
-        let (acbu_rate, oracle_timestamp): (i128, u64) = env.invoke_contract(
-            &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_ACBU_RATE_WITH_TS),
-            vec![&env],
-        );
-        check_oracle_freshness(&env, oracle_timestamp, UPDATE_INTERVAL_SECONDS);
-
-        let (rate, rate_timestamp): (i128, u64) = env.invoke_contract(
-            &oracle_addr,
-            &Symbol::new(&env, ORACLE_GET_RATE_WITH_TS),
-            vec![&env, currency.clone().into_val(&env)],
-        );
-        check_oracle_freshness(&env, rate_timestamp, UPDATE_INTERVAL_SECONDS);
-
-        if rate == 0 {
-            panic!("Invalid oracle rate");
-        }
-
-        let usd_gross = fiat_amount
-            .checked_mul(rate)
-            .and_then(|v| v.checked_div(DECIMALS))
-            .expect("Overflow in usd_gross calculation");
-        if usd_gross < min_amount || usd_gross > max_amount {
-            panic!("Invalid mint amount");
-        }
-
-        let usd_after_fee = calculate_amount_after_fee(usd_gross, fee_single);
-        let acbu_amount = usd_after_fee
-            .checked_mul(DECIMALS)
-            .and_then(|v| v.checked_div(acbu_rate))
-            .expect("Overflow in acbu amount calculation");
-
-        let projected_supply = total_supply
-            .checked_add(acbu_amount)
-            .expect("Overflow in projected supply calculation");
-        Self::check_supply_cap(&env, projected_supply);
-        let reserve_ok: bool = env.invoke_contract(
-            &reserve_tracker_addr,
-            &Symbol::new(&env, RESERVE_IS_SUFFICIENT),
-            vec![&env, projected_supply.into_val(&env)],
-        );
-        if !reserve_ok {
-            panic!("Insufficient reserves: minting would violate the minimum collateral ratio");
-        }
-
-        // Pre-fund custody: the fiat amount is assumed to be held in the contract's balance before this call
-        let custody = env.current_contract_address();
-        let token = soroban_sdk::token::Client::new(&env, &expected_stoken);
-        token.transfer(&custody, &vault, &fiat_amount);
-
-        total_supply += acbu_amount;
-        env.storage()
-            .instance()
-            .set(&DATA_KEY.total_supply, &total_supply);
-
-        let acbu_sac = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
-        acbu_sac.mint(&recipient, &acbu_amount);
-
-        let fee = calculate_fee(usd_gross, fee_single);
-        let mint_event = MintEvent {
-            transaction_id: fintech_tx_id.clone(),
-            user: recipient.clone(),
-            usdc_amount: usd_gross,
-            acbu_amount,
-            fee,
-            rate: acbu_rate,
-            timestamp: env.ledger().timestamp(),
-        };
-        env.events()
-            .publish((symbol_short!("mint"), recipient), mint_event);
-
-        mark_proof_used(&env, &fintech_tx_id);
-        acbu_amount
-    }
 
     pub fn get_operator(env: Env) -> Address {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
@@ -1379,25 +1240,7 @@ fn check_oracle_freshness(env: &Env, oracle_timestamp: u64, max_staleness_second
     }
 }
 
-fn generate_unique_tx_id(env: &Env, _user: &Address, amount: i128, _prefix: &str) -> SorobanString {
-    let timestamp = env.ledger().timestamp();
-    let seq = env.ledger().sequence() as u64;
-    // Mix amount, timestamp, and sequence into a 64-bit hash (no alloc / format! needed).
-    let hash = (amount as u64)
-        .wrapping_mul(0x9e3779b97f4a7c15)
-        .wrapping_add(timestamp.wrapping_mul(0x6c62272e07bb0142))
-        .wrapping_add(seq);
-    // Encode as 16 hex chars using only stack memory — no format! or alloc.
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut buf = [0u8; 16];
-    let mut h = hash;
-    for i in (0..16).rev() {
-        buf[i] = HEX[(h & 0xF) as usize];
-        h >>= 4;
-    }
-    SorobanString::from_str(env, core::str::from_utf8(&buf).unwrap_or("0000000000000000"))
-fn generate_unique_tx_id(env: &Env, _user: &Address, _amount: i128, prefix: &str) -> SorobanString {
-    SorobanString::from_str(env, prefix)
+
 fn generate_unique_tx_id(env: &Env, user: &Address, amount: i128, prefix: &str) -> SorobanString {
     let nonce = next_tx_nonce(env);
     let mut preimage = Bytes::new(env);


### PR DESCRIPTION
### Description
This PR resolves two high-severity issues identified in the smart contracts:
1. **Lending Pool Over-borrowing (#314):** Fixed a vulnerability where borrowers could borrow more than a lender's unborrowed balance.
2. **Minting Overflow (#304):** Handled potential silent overflows and panics during the rate conversion in the `mint_from_usdc` function.

It also resolves multiple duplicate function declarations and corrupt imports at the top of the minting contract file, and adds missing variants to both contract error enums so that the codebase compiles cleanly.

---

### Details of Changes

#### Lending Pool (`acbu_lending_pool`)
- **Balance & Borrowing Rules:**
  - Added `Borrowed(Address)` key to `DataKey` to track the total borrowed amount from each lender.
  - Linked active loans to their lenders by adding a `lender` field to the `LoanData` struct.
  - Modified the `borrow` function to accept a `lender: Address` parameter and assert that `deposited_amount - already_borrowed >= amount`.
  - Decremented the lender's `Borrowed` state on principal repayment in the `repay` function.
  - Restricted lender withdrawals to their available balance (`deposited_amount - already_borrowed`) in the `withdraw` function.
- **Tests & Enums:**
  - Updated all test suites (`test.rs` and `test_comprehensive.rs`) to pass the lender argument in `borrow` calls.
  - Added the missing rotation/timelock variants (`NoPendingAdmin`, `AdminTimelockNotElapsed`, `NoPendingAdminToCancel`) to the `Error` enum.

#### Minting Contract (`acbu_minting`)
- **Checked Math & Error Handling:**
  - Updated the rate calculation in `mint_from_usdc` to cleanly return a `MintingError::InvalidMintAmount` on overflow or division by zero instead of panicking with `.expect`.
- **Codebase Integrity & Cleanup:**
  - Removed duplicate/corrupt imports at the top of the file.
  - Cleaned up duplicate implementations of `generate_unique_tx_id` and the duplicate implementation of `mint_from_fiat` that was causing duplicate symbol issues.
  - Added missing variants (`MaxSupplyExceeded`, `NoPendingAdmin`, `AdminTimelockNotElapsed`, `NoPendingAdminToCancel`) to the `MintingError` enum.
  -closes #304  
closes #314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lending pool now enforces per-lender borrowing limits and prevents withdrawals that exceed available balance
  * Fiat minting now includes transaction ID validation and duplicate transaction prevention

* **Breaking Changes**
  * Lending pool `borrow` operation now requires explicit lender address parameter

* **Improvements**
  * Enhanced error handling and validation across lending and minting contracts
  * Fiat minting now performs stricter operator and oracle freshness verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->