### PR TITLE
Fix oracle admin rate override to emit RateUpdateEvent and add regres…

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -497,11 +497,20 @@ impl OracleContract {
             .instance()
             .get(&DATA_KEY.rates)
             .unwrap_or(Map::new(&env));
-        rates.set(currency, rate_data);
+        rates.set(currency.clone(), rate_data);
         env.storage().instance().set(&DATA_KEY.rates, &rates);
         env.storage()
             .instance()
             .set(&DATA_KEY.last_update, &current_time);
+
+        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
+        let event = RateUpdateEvent {
+            currency,
+            rate,
+            timestamp: current_time,
+            validator: admin,
+        };
+        env.events().publish((symbol_short!("rate_upd"),), event);
     }
 
     pub fn get_rate(env: Env, currency: CurrencyCode) -> i128 {

--- a/acbu_oracle/tests/test.rs
+++ b/acbu_oracle/tests/test.rs
@@ -133,6 +133,54 @@ fn test_update_rate() {
 }
 
 #[test]
+fn test_admin_set_rate_emits_rate_update_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+
+    let mut basket_weights = Map::new(&env);
+    basket_weights.set(ngn.clone(), 10000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &validators, &1u32, &currencies, &basket_weights);
+
+    let admin_rate = 2_000_000i128;
+    client.set_rate_admin(&ngn, &admin_rate);
+
+    let stored_rate = client.get_rate(&ngn);
+    assert_eq!(stored_rate, admin_rate);
+
+    let events = env.events().all();
+    let mut found = false;
+    for event in events.iter() {
+        if event.0 != contract_id {
+            continue;
+        }
+        let topics = event.1;
+        if !topics.is_empty()
+            && Symbol::from_val(&env, &topics.get(0).unwrap()) == symbol_short!("rate_upd")
+        {
+            let event_data: RateUpdateEvent = event.2.into_val(&env);
+            assert_eq!(event_data.currency, ngn.clone());
+            assert_eq!(event_data.rate, admin_rate);
+            assert_eq!(event_data.validator, admin);
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "expected rate_upd event");
+}
+
+#[test]
 fn test_outlier_detection() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Fixed [acbu_oracle](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) admin override so [set_rate_admin](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) now emits [RateUpdateEvent](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) when the admin updates a currency rate.

[lib.rs](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/)
[set_rate_admin](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) now publishes [RateUpdateEvent](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) with the admin as the validator.
[test.rs](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/)
Added regression test [test_admin_set_rate_emits_rate_update_event](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) to verify event emission.
This ensures backend listeners tracking [RateUpdateEvent](https://symmetrical-bassoon-7v5p69j6j7wjcp57w.github.dev/) detect admin-forced rate changes.

closes #309 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate update events to properly include correct admin validation information and preserve currency data.

* **Tests**
  * Added test coverage verifying rate updates emit complete event data with accurate currency, rate, and validator information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->