### PR TITLE
fix: #319 oracle quorum check & #333 reserve tracker add_currency dedup

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -360,7 +360,13 @@ impl OracleContract {
             }
         }
 
-        if sources.len() > 0 && sources.len() < MIN_ORACLE_SOURCE_FEEDS {
+        let min_sigs: u32 = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.min_signatures)
+            .unwrap();
+        let required = min_sigs.max(MIN_ORACLE_SOURCE_FEEDS);
+        if sources.len() < required {
             env.panic_with_error(OracleError::InsufficientOracleSources);
         }
 

--- a/acbu_oracle/src/tests.rs
+++ b/acbu_oracle/src/tests.rs
@@ -113,6 +113,68 @@ fn test_replace_pending_nomination() {
 // ─── sad paths ───────────────────────────────────────────────────────────────
 
 #[test]
+#[should_panic(expected = "#7009")]
+fn test_update_rate_below_min_signatures_panics() {
+    // min_signatures = 3, so sources.len() must be >= 3
+    let env = make_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let (currencies, weights) = dummy_currencies(&env);
+    env.mock_all_auths();
+    // min_signatures = 3, validator set size = 1 (allowed by initialize only when min=1;
+    // use min=1 here but rely on MIN_ORACLE_SOURCE_FEEDS=3 floor)
+    client.initialize(&admin, &validators, &1u32, &currencies, &weights);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut two_sources = Vec::new(&env);
+    two_sources.push_back(100_000_000i128);
+    two_sources.push_back(100_000_000i128);
+    // Only 2 sources but min required is max(min_sigs=1, MIN_ORACLE_SOURCE_FEEDS=3) = 3
+    client.update_rate(&validator, &ngn, &100_000_000i128, &two_sources, &0u64);
+}
+
+#[test]
+fn test_update_rate_meets_quorum_succeeds() {
+    let env = make_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let validator = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(validator.clone());
+
+    let (currencies, weights) = dummy_currencies(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &validators, &1u32, &currencies, &weights);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut three_sources = Vec::new(&env);
+    three_sources.push_back(100_000_000i128);
+    three_sources.push_back(100_000_000i128);
+    three_sources.push_back(100_000_000i128);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 1,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3_110_400,
+    });
+    client.update_rate(&validator, &ngn, &100_000_000i128, &three_sources, &0u64);
+    assert_eq!(client.get_rate(&ngn), 100_000_000i128);
+}
+
+#[test]
 #[should_panic(expected = "#7005")]
 fn test_accept_before_timelock_panics() {
     let (env, _admin, client) = setup();

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -20,6 +20,7 @@ pub enum ReserveTrackerError {
     AdminTimelockNotElapsed = 8005,
     NoPendingAdminToCancel = 8006,
     Unauthorized = 8007,
+    DuplicateCurrency = 8008,
     Unknown = 8999,
 }
 
@@ -34,6 +35,7 @@ pub struct DataKey {
     pub version: Symbol,
     pub pending_admin: Symbol,
     pub pending_admin_eligible_at: Symbol,
+    pub currencies: Symbol,
 }
 
 const DATA_KEY: DataKey = DataKey {
@@ -45,6 +47,7 @@ const DATA_KEY: DataKey = DataKey {
     version: symbol_short!("VERSION"),
     pending_admin: symbol_short!("PEND_ADM"),
     pending_admin_eligible_at: symbol_short!("PEND_ETA"),
+    currencies: symbol_short!("CURRNCYS"),
 };
 
 /// Admin rotation timelock: the pending admin must wait this long before
@@ -251,6 +254,38 @@ impl ReserveTrackerContract {
         Self::check_admin(&env);
         let empty: Map<CurrencyCode, ReserveData> = Map::new(&env);
         env.storage().instance().set(&DATA_KEY.reserves, &empty);
+    }
+
+    // -----------------------------------------------------------------------
+    // Currency list management (admin only)
+    // -----------------------------------------------------------------------
+
+    /// Add a currency to the tracked list. Panics with `DuplicateCurrency` if
+    /// the currency is already present, preventing double-counting of reserves.
+    pub fn add_currency(env: Env, currency: CurrencyCode) {
+        Self::check_admin(&env);
+        let mut currencies: Vec<CurrencyCode> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.currencies)
+            .unwrap_or(Vec::new(&env));
+        for c in currencies.iter() {
+            if c == currency {
+                env.panic_with_error(ReserveTrackerError::DuplicateCurrency);
+            }
+        }
+        currencies.push_back(currency);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.currencies, &currencies);
+    }
+
+    /// Return the list of tracked currencies.
+    pub fn get_currencies(env: Env) -> Vec<CurrencyCode> {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.currencies)
+            .unwrap_or(Vec::new(&env))
     }
 
     // -----------------------------------------------------------------------

--- a/acbu_reserve_tracker/tests/test.rs
+++ b/acbu_reserve_tracker/tests/test.rs
@@ -290,6 +290,51 @@ fn test_verify_reserves_errors_when_total_supply_is_zero() {
 }
 
 #[test]
+fn test_add_currency_and_get_currencies() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let acbu_token = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    assert_eq!(client.get_currencies().len(), 0);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    client.add_currency(&ngn);
+    assert_eq!(client.get_currencies().len(), 1);
+
+    let kes = CurrencyCode::new(&env, "KES");
+    client.add_currency(&kes);
+    assert_eq!(client.get_currencies().len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "#8008")]
+fn test_add_currency_duplicate_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let acbu_token = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    client.add_currency(&ngn);
+    client.add_currency(&ngn); // should panic with DuplicateCurrency = 8008
+}
+
+#[test]
 fn test_update_reserve_without_admin_auth_fails() {
     let env = Env::default();
     env.ledger().with_mut(|l| l.timestamp = 1);


### PR DESCRIPTION
closes #319 
closes #333 

#319 (acbu_oracle/src/lib.rs): update_rate previously allowed a single validator submission to bypass the source-count floor when sources was empty, and used only the hardcoded MIN_ORACLE_SOURCE_FEEDS constant rather than the configured min_signatures. Replace the conditional guard with an unconditional check that enforces max(min_signatures, MIN_ORACLE_SOURCE_FEEDS) sources, so a solitary malicious validator can never set a rate with fewer independent feeds than the quorum requires.

#333 (acbu_reserve_tracker/src/lib.rs): add add_currency() (admin-only) that iterates the currencies Vec before pushing and panics with DuplicateCurrency (8008) if the entry already exists, preventing double-counting of reserves in iteration-based totals. Also adds get_currencies() accessor and the backing storage key.

Tests added for both fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-managed currency tracking in the reserve tracker, including the ability to add currencies and view the full supported list.
  * Improved oracle rate validation so updates now require enough source feeds based on the configured quorum.

* **Bug Fixes**
  * Duplicate currencies are now rejected when adding to the tracked list.
  * Oracle updates now fail consistently when the provided source count is below the required minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->