### PR TITLE
test: guard set_fee_rate basis-points validation (#317)

### DIFF
--- a/acbu_minting/tests/test.rs
+++ b/acbu_minting/tests/test.rs
@@ -718,3 +718,61 @@ fn test_update_oracle_requires_admin_minting() {
     // With mock_all_auths this succeeds; the auth check is enforced by Soroban's auth framework
     client2.update_oracle(&new_oracle);
 }
+
+// --- Fee-rate range validation (#317) ---
+
+#[test]
+fn test_set_fee_rate_accepts_in_range() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, oracle, reserve_tracker, acbu_token, usdc_token, client) = setup_test(&env);
+    let vault = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    init_mint_client(&env, &client, &admin, &oracle, &reserve_tracker, &acbu_token, &usdc_token, &vault, &treasury, 100, 200);
+
+    // The upper bound (BASIS_POINTS == 100%) is accepted.
+    client.set_fee_rate(&10_000);
+    assert_eq!(client.get_fee_rate(), 10_000);
+    client.set_fee_rate(&0);
+    assert_eq!(client.get_fee_rate(), 0);
+}
+
+#[test]
+#[should_panic(expected = "#5002")]
+fn test_set_fee_rate_rejects_above_basis_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, oracle, reserve_tracker, acbu_token, usdc_token, client) = setup_test(&env);
+    let vault = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    init_mint_client(&env, &client, &admin, &oracle, &reserve_tracker, &acbu_token, &usdc_token, &vault, &treasury, 100, 200);
+
+    // A fee above 10,000 bps (>100%) would silence mints / underflow fee math, so it must revert.
+    client.set_fee_rate(&10_001);
+}
+
+#[test]
+#[should_panic(expected = "#5002")]
+fn test_set_fee_rate_rejects_negative() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, oracle, reserve_tracker, acbu_token, usdc_token, client) = setup_test(&env);
+    let vault = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    init_mint_client(&env, &client, &admin, &oracle, &reserve_tracker, &acbu_token, &usdc_token, &vault, &treasury, 100, 200);
+
+    client.set_fee_rate(&-1);
+}
+
+#[test]
+#[should_panic(expected = "#5002")]
+fn test_set_fee_single_rejects_above_basis_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, oracle, reserve_tracker, acbu_token, usdc_token, client) = setup_test(&env);
+    let vault = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    init_mint_client(&env, &client, &admin, &oracle, &reserve_tracker, &acbu_token, &usdc_token, &vault, &treasury, 100, 200);
+
+    client.set_fee_single(&10_001);
+}


### PR DESCRIPTION

closes #317

### Context
Issue #317 reported that `set_fee_rate` in the minting contract did not validate
`fee_bps <= BASIS_POINTS`, allowing a fee >100% that would silence mints entirely
or cause integer underflow in fee math.

### Findings
The current dev branch already enforces the bound: both `set_fee_rate` and
`set_fee_single` reject any value outside `0..=BASIS_POINTS` with
`MintingError::InvalidFeeRate` (error code 5002). The `initialize` path applies
the same guard. What was missing was test coverage asserting this behavior, so
the guard was unprotected against future regressions.

### Changes
Added regression tests in `acbu_minting/tests/test.rs`:
- `test_set_fee_rate_accepts_in_range` — accepts 0 and the 10,000 bps (100%) bound.
- `test_set_fee_rate_rejects_above_basis_points` — rejects 10,001 bps with #5002.
- `test_set_fee_rate_rejects_negative` — rejects negative fees with #5002.
- `test_set_fee_single_rejects_above_basis_points` — same upper-bound guard for the single-deposit fee tier.

No production code was modified; the existing validation is preserved and now
covered by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for fee configuration limits.
  * Verified valid fee-rate values within the allowed range.
  * Added failure checks for fee-rate values above the maximum, negative values, and fee-single values above the maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->