### PR TITLE
fix

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -35,6 +35,7 @@ pub enum OracleError {
     NoPendingValidatorChange = 7019,
     ValidatorTimelockNotElapsed = 7020,
     MaxValidatorsReached = 7021,
+    TimestampRollback = 7022,
     Unknown = 7999,
 }
 
@@ -346,6 +347,11 @@ impl OracleContract {
         let current_time = env.ledger().timestamp();
 
         let existing_rate = Self::get_rate_internal(&env, &currency);
+        if let Some(ref existing) = existing_rate {
+            if current_time < existing.timestamp {
+                env.panic_with_error(OracleError::TimestampRollback);
+            }
+        }
         let mut allow_update = false;
         if let Some(existing_rate) = existing_rate.clone() {
             let deviation = calculate_deviation(rate, existing_rate.rate_usd);
@@ -426,6 +432,13 @@ impl OracleContract {
             env.panic_with_error(OracleError::InvalidRate);
         }
         let current_time = env.ledger().timestamp();
+
+        let existing_rate = Self::get_rate_internal(&env, &currency);
+        if let Some(ref existing) = existing_rate {
+            if current_time < existing.timestamp {
+                env.panic_with_error(OracleError::TimestampRollback);
+            }
+        }
         let rate_data = RateData {
             currency: currency.clone(),
             rate_usd: rate,


### PR DESCRIPTION
Fixed the timestamp monotonicity issue in acbu_oracle/src/lib.rs:

Changes made:

Added TimestampRollback = 7022 error code to OracleError enum
Added timestamp check in update_rate function (line 350-354) to ensure current_time >= existing.timestamp before allowing updates
Added timestamp check in set_rate_admin function (line 436-441) with the same validation
Both rate update functions now panic with TimestampRollback if the ledger timestamp is less than the previously stored timestamp, preventing older epochs from overwriting newer ones on networks with clock drift or testnet resets.

closes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard to prevent rate updates from accepting older timestamps than the currently stored value.
  * Applied the same timestamp rollback check when changing the rate administrator, helping avoid overwriting newer data with stale information.
  * Updated an error code mapping to reflect the new rollback-related condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->