### PR TITLE
[codex] Fix contract warnings and targeted tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,5 +34,72 @@ jobs:
       - name: Fetch token WASM artifact
         run: bash scripts/fetch_token_wasm.sh
 
+      - name: Determine changed packages
+        id: changed
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
+
+          packages=()
+          add_package() {
+            local package="$1"
+            for existing in "${packages[@]}"; do
+              if [[ "$existing" == "$package" ]]; then
+                return
+              fi
+            done
+            packages+=("$package")
+          }
+
+          while IFS= read -r file; do
+            case "$file" in
+              shared/*)
+                echo "shared crate changed; running full workspace"
+                echo "workspace=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              acbu_burning/*) add_package acbu_burning ;;
+              acbu_escrow/*) add_package acbu_escrow ;;
+              acbu_lending_pool/*) add_package acbu_lending_pool ;;
+              acbu_minting/*) add_package acbu_minting ;;
+              acbu_multisig/*) add_package acbu_multisig ;;
+              acbu_oracle/*) add_package acbu_oracle ;;
+              acbu_reserve_tracker/*) add_package acbu_reserve_tracker ;;
+              acbu_savings_vault/*) add_package acbu_savings_vault ;;
+              Cargo.toml|Cargo.lock|rust-toolchain.toml|build.rs|.github/workflows/tests.yml)
+                echo "workspace-level file changed; running full workspace"
+                echo "workspace=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              tests/*)
+                echo "integration tests changed; running full workspace"
+                echo "workspace=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [[ ${#packages[@]} -eq 0 ]]; then
+            echo "workspace=false" >> "$GITHUB_OUTPUT"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+          else
+            printf -v package_args ' -p %s' "${packages[@]}"
+            echo "workspace=false" >> "$GITHUB_OUTPUT"
+            echo "packages=${package_args# }" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run changed contract tests
+        if: github.event_name == 'pull_request' && steps.changed.outputs.workspace != 'true' && steps.changed.outputs.packages != ''
+        run: cargo test ${{ steps.changed.outputs.packages }}
+
+      - name: Skip tests for docs-only PR
+        if: github.event_name == 'pull_request' && steps.changed.outputs.workspace != 'true' && steps.changed.outputs.packages == ''
+        run: echo "No Rust package changes detected."
+
       - name: Run all tests
+        if: github.event_name != 'pull_request' || steps.changed.outputs.workspace == 'true'
         run: cargo test --workspace

--- a/acbu_burning/tests/redeem_single.rs
+++ b/acbu_burning/tests/redeem_single.rs
@@ -70,7 +70,6 @@ fn test_redeem_single_fee_calculation() {
         .redeem_single(&ctx.user, &recipient, &burn_amount, &currency);
 
     // Verify fee: 2% of 100 * DECIMALS = 2 * DECIMALS
-    let _expected_fee = 2 * DECIMALS;
     let expected_out = 98 * DECIMALS;
     assert_eq!(out, expected_out);
     assert_eq!(stoken_client.balance(&recipient), expected_out);

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -43,6 +43,13 @@ const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
 pub struct LoanId(pub Address, pub u64);
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoanStatus {
+    Active,
+    Repaid,
+}
+
+#[contracttype]
 #[derive(Clone, Debug)]
 pub struct LoanData {
     pub borrower: Address,
@@ -54,6 +61,7 @@ pub struct LoanData {
     pub repayment_deadline: u64,
     pub accrued_interest: i128,
     pub total_repayment_due: i128,
+    pub status: LoanStatus,
 }
 
 #[contracttype]
@@ -343,7 +351,7 @@ impl LendingPool {
 
         let fee_rate_bps: i128 = env.storage().instance().get(&DataKey::FeeRate).unwrap_or(0);
         let start_time = env.ledger().timestamp();
-        
+
         let loan_data = LoanData {
             borrower: borrower.clone(),
             lender: lender.clone(),
@@ -354,8 +362,9 @@ impl LendingPool {
             repayment_deadline: start_time + (30 * 24 * 60 * 60),
             accrued_interest: 0,
             total_repayment_due: amount,
+            status: LoanStatus::Active,
         };
-        
+
         env.storage()
             .persistent()
             .set(&DataKey::Loan(loan_key), &loan_data);
@@ -398,6 +407,10 @@ impl LendingPool {
         let loan_key = LoanId(borrower, loan_id);
         let mut loan_data: LoanData = env.storage().persistent().get(&DataKey::Loan(loan_key))?;
 
+        if let LoanStatus::Repaid = loan_data.status {
+            return Some(loan_data);
+        }
+
         let current_time = env.ledger().timestamp();
         let elapsed = current_time.saturating_sub(loan_data.loan_start_timestamp);
 
@@ -437,6 +450,9 @@ impl LendingPool {
         if amount > loan_data.total_repayment_due {
             env.panic_with_error(Error::InvalidAmount);
         }
+        if let LoanStatus::Repaid = loan_data.status {
+            env.panic_with_error(Error::InvalidState);
+        }
 
         let acbu_token: Address = env.storage().instance().get(&DataKey::AcbuToken).unwrap();
         let token = soroban_sdk::token::Client::new(&env, &acbu_token);
@@ -450,8 +466,17 @@ impl LendingPool {
         // CEI: Update state before external calls
         loan_data.amount = loan_data.amount.checked_sub(principal_repaid).unwrap_or(0);
 
-        let active_loans_liquidity: i128 = env.storage().instance().get(&DataKey::ActiveLoansLiquidity).unwrap_or(0);
-        env.storage().instance().set(&DataKey::ActiveLoansLiquidity, &active_loans_liquidity.checked_sub(principal_repaid).unwrap_or(0));
+        let active_loans_liquidity: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveLoansLiquidity)
+            .unwrap_or(0);
+        env.storage().instance().set(
+            &DataKey::ActiveLoansLiquidity,
+            &active_loans_liquidity
+                .checked_sub(principal_repaid)
+                .unwrap_or(0),
+        );
 
         if principal_repaid > 0 {
             let lender = loan_data.lender.clone();
@@ -476,7 +501,15 @@ impl LendingPool {
                     &loan_data.collateral_amount,
                 );
             }
-            env.storage().persistent().remove(&DataKey::Loan(loan_key));
+            loan_data.collateral_amount = 0;
+            loan_data.accrued_interest = 0;
+            loan_data.total_repayment_due = 0;
+            loan_data.loan_start_timestamp = env.ledger().timestamp();
+            loan_data.status = LoanStatus::Repaid;
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Loan(loan_key), &loan_data);
         } else {
             loan_data.loan_start_timestamp = env.ledger().timestamp();
             let remaining_interest = if amount < loan_data.accrued_interest {

--- a/acbu_lending_pool/tests/test.rs
+++ b/acbu_lending_pool/tests/test.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 
-use acbu_lending_pool::{BorrowEvent, LendingPool, LendingPoolClient, RepayEvent};
+use acbu_lending_pool::{
+    BorrowEvent, LendingPool, LendingPoolClient, LoanStatus, RepayEvent, RepaymentEvent,
+};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events, Ledger},
@@ -297,11 +299,11 @@ fn test_repay_basic() {
     // Borrower now holds borrow_amount tokens; repay the full amount
     client.repay(&borrower, &borrow_amount, &loan_id);
 
-    // Loan must be removed after full repayment
-    assert!(
-        client.get_loan(&borrower, &loan_id).is_none(),
-        "loan must be cleared after full repayment"
-    );
+    let loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("repaid loan state must remain available");
+    assert_eq!(loan.amount, 0);
+    assert!(matches!(loan.status, LoanStatus::Repaid));
 
     // Pool token balance is restored to original liquidity
     assert_eq!(token_client.balance(&contract_id), pool_liquidity);
@@ -487,10 +489,11 @@ fn test_borrow_repay_full_lifecycle() {
 
     assert_eq!(token_client.balance(&borrower), collateral);
     assert_eq!(token_client.balance(&contract_id), pool_liquidity);
-    assert!(
-        client.get_loan(&borrower, &loan_id).is_none(),
-        "loan must be gone after full repayment"
-    );
+    let repaid_loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("repaid loan state must remain available");
+    assert_eq!(repaid_loan.amount, 0);
+    assert!(matches!(repaid_loan.status, LoanStatus::Repaid));
 
     // ── Step 4: lender withdraws ──────────────────────────────────────────────
     client.withdraw(&lender, &pool_liquidity);
@@ -516,7 +519,6 @@ fn test_loan_lifecycle_emits_events() {
     let token_id = env
         .register_stellar_asset_contract_v2(token_admin.clone())
         .address();
-    let _token_client = TokenClient::new(&env, &token_id);
     let token_admin_client = StellarAssetClient::new(&env, &token_id);
 
     let contract_id = env.register_contract(None, LendingPool);
@@ -596,9 +598,32 @@ fn test_loan_lifecycle_emits_events() {
     assert_eq!(repay_event_data.token, token_id);
     assert_eq!(repay_event_data.loan_id, loan_id);
 
-    // 3. Repay full - loan removed
+    // 3. Repay full - loan state retained as repaid
     client.repay(&borrower, &(borrow_amount - repay_amount), &loan_id);
 
-    // Assert loan deleted after full repayment
-    assert!(client.get_loan(&borrower, &loan_id).is_none());
+    let repaid_loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("repaid loan state must remain available");
+    assert_eq!(repaid_loan.amount, 0);
+    assert!(matches!(repaid_loan.status, LoanStatus::Repaid));
+
+    let events = env.events().all();
+    let repayment_event = events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.1.first().map_or(false, |t| {
+                if let Ok(symbol_val) =
+                    TryIntoVal::<_, soroban_sdk::Symbol>::try_into_val(&t, &env)
+                {
+                    symbol_val == symbol_short!("repaymt")
+                } else {
+                    false
+                }
+            })
+        })
+        .expect("repayment event not found");
+    let repayment_event_data: RepaymentEvent = repayment_event.2.try_into_val(&env).unwrap();
+    assert_eq!(repayment_event_data.borrower, borrower);
+    assert_eq!(repayment_event_data.amount, borrow_amount - repay_amount);
 }

--- a/acbu_lending_pool/tests/test_comprehensive.rs
+++ b/acbu_lending_pool/tests/test_comprehensive.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use acbu_lending_pool::{BorrowEvent, LendingPool, LendingPoolClient, RepayEvent};
+use acbu_lending_pool::{BorrowEvent, LendingPool, LendingPoolClient, LoanStatus, RepayEvent};
 use shared::DECIMALS;
 use soroban_sdk::{
     symbol_short,
@@ -391,7 +391,11 @@ fn test_repay_full_removes_loan() {
     client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     client.repay(&borrower, &borrow_amount, &loan_id);
 
-    assert!(client.get_loan(&borrower, &loan_id).is_none());
+    let loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("repaid loan state should remain available");
+    assert_eq!(loan.amount, 0);
+    assert!(matches!(loan.status, LoanStatus::Repaid));
 }
 
 #[test]
@@ -412,7 +416,6 @@ fn test_repay_full_returns_collateral() {
 
     client.deposit(&lender, &pool_liquidity);
     
-    let _borrower_balance_before = token_client.balance(&borrower);
     client.borrow(&borrower, &lender, &borrow_amount, &collateral, &loan_id);
     
     // After borrow: borrower has borrow_amount (collateral was transferred to contract)

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -1443,7 +1443,6 @@ fn validate_fintech_tx_id(env: &Env, id: &SorobanString) {
             env.panic_with_error(MintingError::FintechTxIdInvalidChar);
         }
     }
-    let _ = env; // env kept in signature for future on-chain logging
 }
 
 fn normalize_fintech_tx_id(env: &Env, id: &SorobanString) -> SorobanString {

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -533,6 +533,9 @@ impl OracleContract {
             .instance()
             .get(&DATA_KEY.currencies)
             .unwrap_or(Vec::new(&env));
+        if currencies.is_empty() {
+            return (DECIMALS, 0);
+        }
 
         let mut weighted_sum = 0i128;
         let mut total_weight = 0i128;
@@ -579,6 +582,9 @@ impl OracleContract {
             .instance()
             .get(&DATA_KEY.currencies)
             .unwrap_or(Vec::new(&env));
+        if currencies.is_empty() {
+            return DECIMALS;
+        }
 
         let mut weighted_sum = 0i128;
         let mut total_weight = 0i128;
@@ -947,6 +953,9 @@ impl OracleContract {
             .instance()
             .get(&DATA_KEY.currencies)
             .unwrap_or(Vec::new(env));
+        if currencies.is_empty() {
+            env.panic_with_error(OracleError::CurrencyNotRegistered);
+        }
         if !currencies.contains(currency.clone()) {
             env.panic_with_error(OracleError::CurrencyNotRegistered);
         }


### PR DESCRIPTION
## Summary

- retain repaid lending-pool loan records with an explicit `Repaid` status and verify repayment events
- add early returns for empty oracle currency lists before iteration
- remove underscore-discarded unused computations/statements from tests and minting code
- run PR tests only for changed contract packages, falling back to full workspace tests for shared/workspace-level changes

## Validation

- `git diff --check`
- `grep -R "let _.*=" -n acbu_* shared/src tests --exclude-dir=target || true`

Rust validation was not run locally because this workspace image does not currently have `cargo` installed/on PATH; GitHub Actions installs Rust and should run the project test workflow.

## Notes

Adding `LoanStatus` extends the `LoanData` contract type so repaid loans remain queryable. Reviewers should confirm whether any live outstanding loan records need an explicit migration before deployment.

Closes #349
Closes #364
Closes #359
Closes #329
