### PR TITLE
fix(#396,#403): add CONTRACT_VERSION increment reminder; reference au…

### DIFF
--- a/WASM_INTEGRITY.md
+++ b/WASM_INTEGRITY.md
@@ -165,10 +165,17 @@ EXPECTED_HASH="NEW_HASH_HERE"
 
 ### 4. Verify Consistency
 
+Run the automated verification script before building:
+
 ```bash
-# Build will verify all hashes match
+# Automated script verifies hash across all contracts and fails fast on mismatch
+./scripts/verify_wasm_hash.sh
+
+# Build will also verify hashes via build.rs
 cargo build --target wasm32-unknown-unknown --release
 ```
+
+CI will re-run the same checks automatically via `.github/workflows/verify-wasm-integrity.yml` on push/PR.
 
 ### 5. Create PR with Changes
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -78,6 +78,8 @@ pub struct ProposalExecutedEvent {
     pub executed_by: Address,
 }
 
+/// Increment this constant with every bug fix, feature addition, or breaking change
+/// so that patched deployments can be distinguished from unpatched ones.
 pub const CONTRACT_VERSION: u32 = 1;
 
 /// Currency code type (e.g., "NGN", "KES", "RWF").


### PR DESCRIPTION
closes #396 
closes #403 

 #396 — CONTRACT_VERSION not incremented after contract changes
  
  Added a doc comment above CONTRACT_VERSION in shared/src/lib.rs instructing developers to increment the constant on every bug fix,
  feature addition, or breaking change. All contracts import this single constant, so the reminder is in one authoritative place.
  
  #403 — WASM_INTEGRITY.md should reference automated scripts
  
  Replaced the bare cargo build snippet in the Updating the WASM Hash → Verify Consistency step with an explicit call to
  scripts/verify_wasm_hash.sh and a note that CI reruns the same checks via .github/workflows/verify-wasm-integrity.yml on every
  push/PR.
  
  Changes
  - shared/src/lib.rs — doc comment on CONTRACT_VERSION
  - WASM_INTEGRITY.md — step 4 of Updating the WASM Hash now references the automated script and CI workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer verification steps for WASM builds, including an explicit hash-check step before compiling.
  * Clarified that the automated verification checks hashes across all contracts and stops immediately if a mismatch is found.
  * Added guidance for maintainers to update the contract version when shipping bug fixes, new features, or breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->