### PR TITLE
Add root Makefile for common build/test/deploy commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.DEFAULT_GOAL := help
+
+SHELL := /bin/bash
+MAKEFLAGS += --silent
+
+.PHONY: help build build-minting test test-minting deploy-testnet deploy-mainnet setup-hooks
+
+help:
+	@printf "Usage:\n"
+	@printf "  make build             Build all contracts\n"
+	@printf "  make test              Run all workspace tests\n"
+	@printf "  make deploy-testnet    Deploy to Stellar testnet\n"
+	@printf "  make deploy-mainnet    Deploy to Stellar mainnet\n"
+	@printf "  make setup-hooks       Install git hooks for the repository\n"
+	@printf "  make build-minting     Build the acbu_minting contract\n"
+	@printf "  make test-minting      Run tests for the acbu_minting contract\n"
+
+build:
+	@printf "Building all contracts...\n"
+	cargo build --target wasm32-unknown-unknown --release
+
+build-minting:
+	@printf "Building acbu_minting contract...\n"
+	cd acbu_minting && cargo build --target wasm32-unknown-unknown --release
+
+test:
+	@printf "Running workspace tests...\n"
+	cargo test
+
+test-minting:
+	@printf "Running acbu_minting tests...\n"
+	cd acbu_minting && cargo test
+
+deploy-testnet:
+	@if [ -z "$$STELLAR_SECRET_KEY" ]; then \
+		echo "ERROR: STELLAR_SECRET_KEY must be set for deployment."; \
+		exit 1; \
+	fi
+	@printf "Deploying to testnet...\n"
+	./scripts/deploy_testnet.sh
+
+deploy-mainnet:
+	@if [ -z "$$STELLAR_SECRET_KEY" ]; then \
+		echo "ERROR: STELLAR_SECRET_KEY must be set for deployment."; \
+		exit 1; \
+	fi
+	@printf "Deploying to mainnet...\n"
+	./scripts/deploy_mainnet.sh
+
+setup-hooks:
+	@printf "Setting up git hooks...\n"
+	./scripts/setup-git-hooks.sh

--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@ Soroban (Stellar) smart contracts for the ACBU (African Currency Basket Unit) st
 
 ## Building
 
+You can use the new `Makefile` for common commands.
+
 ```bash
 # Build all contracts in the workspace
-cargo build --target wasm32-unknown-unknown --release
+make build
 
-# Build specific contract
-cd acbu_minting
-cargo build --target wasm32-unknown-unknown --release
+# Build a specific contract
+make build-minting
 ```
 
 ## Testing
 
 ```bash
 # Run all tests in the workspace
-cargo test
+make test
 
-# Run tests for specific contract
-cd acbu_minting
-cargo test
+# Run tests for a specific contract
+make test-minting
 ```
 
 ## Deployment
@@ -43,20 +43,22 @@ cargo test
 
 ```bash
 export STELLAR_SECRET_KEY="your-secret-key"
-./scripts/deploy_testnet.sh
+make deploy-testnet
 ```
 
 ### Mainnet
 
 ```bash
 export STELLAR_SECRET_KEY="your-secret-key"
-./scripts/deploy_mainnet.sh
+make deploy-mainnet
 ```
 
-**Warning:** Only deploy to mainnet after:
-1. Testing on testnet
-2. Security audit completion
-3. Backup of secret keys
+## Git Hooks Setup
+
+After cloning, run:
+```bash
+make setup-hooks
+```
 
 ## Contract Addresses
 


### PR DESCRIPTION
Closes #389 

Add a root Makefile to simplify common workspace operations such as build, test, and deployment. Document the new commands in README.md for easier onboarding and reduced CLI friction.