### PR TITLE
fix: resolve issues #380, #381, #382, #383

### DIFF
--- a/acbu_burning/tests/gas_estimation.rs
+++ b/acbu_burning/tests/gas_estimation.rs
@@ -56,7 +56,7 @@ fn gas_redeem_basket_five_currency_path_stays_under_budget() {
         .burning
         .redeem_basket(&ctx.user, &recipients, &burn_amount);
 
-    assert_eq!(amounts.len(), currency_codes.len() as u32);
+    assert_eq!(amounts.len(), u32::try_from(currency_codes.len()).unwrap());
     for i in 0..amounts.len() {
         assert_eq!(
             amounts.get(i).unwrap(),

--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -527,17 +527,5 @@ impl Escrow {
 }
 
 #[cfg(test)]
-extern crate alloc;
-
-#[cfg(test)]
-mod tests {
-    use super::EscrowError;
-    use alloc::string::ToString;
-
-    #[test]
-    fn error_display_is_human_readable() {
-        assert_eq!(EscrowError::Paused.to_string(), "escrow is paused");
-    }
-}
 
 

--- a/acbu_escrow/tests/test_error_display.rs
+++ b/acbu_escrow/tests/test_error_display.rs
@@ -1,0 +1,9 @@
+#![cfg(test)]
+
+use acbu_escrow::EscrowError;
+use std::string::ToString;
+
+#[test]
+fn error_display_is_human_readable() {
+    assert_eq!(EscrowError::Paused.to_string(), "escrow is paused");
+}

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -357,7 +357,8 @@ impl LendingPool {
             lender: lender.clone(),
             amount,
             collateral_amount,
-            interest_rate_bps: fee_rate_bps as u32,
+            interest_rate_bps: u32::try_from(fee_rate_bps)
+                .unwrap_or_else(|_| env.panic_with_error(Error::InvalidAmount)),
             loan_start_timestamp: start_time,
             repayment_deadline: start_time + (30 * 24 * 60 * 60),
             accrued_interest: 0,

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -838,4 +838,6 @@ impl LendingPool {
     }
 }
 
-fn migrate_v0_to_v1(_env: Env) {}
+fn migrate_v0_to_v1(_env: Env) {
+    // No storage schema changes between v0 and v1.
+}

--- a/acbu_minting/tests/admin_drip_test.rs
+++ b/acbu_minting/tests/admin_drip_test.rs
@@ -9,7 +9,10 @@ use soroban_sdk::{
 };
 
 mod oracle_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+    use shared::CurrencyCode;
+    use super::DECIMALS;
 
     #[contract]
     pub struct MockOracle;
@@ -49,7 +52,8 @@ mod oracle_mock {
 }
 
 mod reserve_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Env};
+
     #[contract]
     pub struct MockReserveTracker;
 

--- a/acbu_minting/tests/test.rs
+++ b/acbu_minting/tests/test.rs
@@ -11,8 +11,10 @@ use soroban_sdk::{
 // --- Mocks ---
 
 mod oracle_mock {
-    use super::*;
     use shared::CurrencyCode;
+    use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+    use super::DECIMALS;
 
     #[contract]
     pub struct MockOracle;
@@ -59,7 +61,8 @@ mod oracle_mock {
 }
 
 mod reserve_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Env};
+
     #[contract]
     pub struct MockReserveTracker;
 
@@ -72,7 +75,8 @@ mod reserve_mock {
 }
 
 mod failing_reserve_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Env};
+
     #[contract]
     pub struct MockFailingReserveTracker;
 

--- a/acbu_minting/tests/test_fintech_tx_id_validation.rs
+++ b/acbu_minting/tests/test_fintech_tx_id_validation.rs
@@ -31,7 +31,10 @@ use soroban_sdk::{
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 mod oracle_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+    use shared::CurrencyCode;
+    use super::DECIMALS;
 
     #[contract]
     pub struct MockOracle;
@@ -60,7 +63,7 @@ mod oracle_mock {
 }
 
 mod reserve_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Env};
 
     #[contract]
     pub struct MockReserveTracker;

--- a/acbu_minting/tests/test_mint_from_fiat.rs
+++ b/acbu_minting/tests/test_mint_from_fiat.rs
@@ -11,8 +11,10 @@ use soroban_sdk::{
 // --- Mocks (reuse from test.rs) ---
 
 mod oracle_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
     use shared::CurrencyCode;
+    use super::DECIMALS;
 
     #[contract]
     pub struct MockOracle;
@@ -59,7 +61,7 @@ mod oracle_mock {
 }
 
 mod reserve_mock {
-    use super::*;
+    use soroban_sdk::{contract, contractimpl, Env};
 
     #[contract]
     pub struct MockReserveTracker;

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -971,4 +971,6 @@ impl OracleContract {
     }
 }
 mod tests;
-fn migrate_v0_to_v1(_env: Env) {}
+fn migrate_v0_to_v1(_env: Env) {
+    // No storage schema changes between v0 and v1.
+}

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -70,7 +70,7 @@ impl Display for OracleError {
     }
 }
 
-const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
+pub const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
 const MIN_ORACLE_SOURCE_FEEDS: u32 = 3;
 
 #[contracttype]
@@ -970,7 +970,6 @@ impl OracleContract {
         admin.require_auth();
     }
 }
-mod tests;
 fn migrate_v0_to_v1(_env: Env) {
     // No storage schema changes between v0 and v1.
 }

--- a/acbu_oracle/tests/test_admin.rs
+++ b/acbu_oracle/tests/test_admin.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     Address, Env, IntoVal, Map, Vec,
 };
 
-use crate::{OracleContract, OracleContractClient, ADMIN_TIMELOCK_SECONDS};
+use acbu_oracle::{OracleContract, OracleContractClient, ADMIN_TIMELOCK_SECONDS};
 use shared::CurrencyCode;
 
 fn make_env() -> Env {
@@ -21,7 +21,6 @@ fn dummy_currencies(env: &Env) -> (Vec<CurrencyCode>, Map<CurrencyCode, i128>) {
     (currencies, weights)
 }
 
-/// Advance the ledger timestamp by `delta` seconds.
 fn advance_time(env: &Env, delta: u64) {
     let now = env.ledger().timestamp();
     env.ledger().set(LedgerInfo {
@@ -54,8 +53,6 @@ fn setup() -> (Env, Address, OracleContractClient<'static>) {
     (env, admin, client)
 }
 
-// ─── happy path ──────────────────────────────────────────────────────────────
-
 #[test]
 fn test_transfer_and_accept_after_timelock() {
     let (env, _admin, client) = setup();
@@ -63,14 +60,12 @@ fn test_transfer_and_accept_after_timelock() {
 
     env.mock_all_auths();
 
-    // Step 1 – initiate
     client.transfer_admin(&new_admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
 
     let eta = client.get_pending_admin_eligible_at().unwrap();
     assert_eq!(eta, env.ledger().timestamp() + ADMIN_TIMELOCK_SECONDS);
 
-    // Step 2 – advance past timelock and accept
     advance_time(&env, ADMIN_TIMELOCK_SECONDS + 1);
     client.accept_admin();
 
@@ -89,7 +84,6 @@ fn test_cancel_clears_pending_state() {
     client.cancel_admin_transfer();
 
     assert!(client.get_pending_admin().is_none());
-    // Original admin unchanged
     assert_ne!(client.get_admin(), new_admin);
 }
 
@@ -101,7 +95,6 @@ fn test_replace_pending_nomination() {
 
     env.mock_all_auths();
     client.transfer_admin(&wrong_addr);
-    // Correct the mistake before timelock expires
     client.transfer_admin(&correct_addr);
     assert_eq!(client.get_pending_admin(), Some(correct_addr.clone()));
 
@@ -109,8 +102,6 @@ fn test_replace_pending_nomination() {
     client.accept_admin();
     assert_eq!(client.get_admin(), correct_addr);
 }
-
-// ─── sad paths ───────────────────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected = "#7005")]
@@ -120,7 +111,6 @@ fn test_accept_before_timelock_panics() {
 
     env.mock_all_auths();
     client.transfer_admin(&new_admin);
-    // Do NOT advance time → should panic
     client.accept_admin();
 }
 
@@ -146,7 +136,6 @@ fn test_transfer_admin_requires_current_admin_auth() {
     let attacker = Address::generate(&env);
     let victim = Address::generate(&env);
 
-    // Only mock auth for the attacker (not the real admin) → should panic
     env.mock_auths(&[soroban_sdk::testutils::MockAuth {
         address: &attacker,
         invoke: &soroban_sdk::testutils::MockAuthInvoke {
@@ -159,7 +148,6 @@ fn test_transfer_admin_requires_current_admin_auth() {
     client.transfer_admin(&victim);
 }
 
-// Single vs multiple submission optimization
 #[test]
 fn test_update_rate_single_submission() {
     let (env, _admin, client) = setup();

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -392,5 +392,5 @@ impl ReserveTrackerContract {
 }
 
 fn migrate_v0_to_v1(_env: Env) {
-    // Migration logic
+    // No storage schema changes between v0 and v1.
 }

--- a/acbu_savings_vault/tests/test.rs
+++ b/acbu_savings_vault/tests/test.rs
@@ -425,9 +425,9 @@ fn test_withdraw_event_yield_amount_nonzero_issue_225() {
     let principal = DECIMALS;
     let term_seconds = 30 * 24 * 3600u64;
 
-    let elapsed = term_seconds as i128;
+    let elapsed = i128::from(term_seconds);
     let expected_yield =
-        principal * yield_rate_bps * elapsed / (10_000 * SECONDS_PER_YEAR as i128);
+        principal * yield_rate_bps * elapsed / (10_000 * i128::from(SECONDS_PER_YEAR));
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &acbu_token);
     token_admin.mint(&user, &principal);

--- a/acbu_savings_vault/tests/test_comprehensive.rs
+++ b/acbu_savings_vault/tests/test_comprehensive.rs
@@ -133,7 +133,7 @@ impl TestEnv {
 
 fn expected_yield(principal: i128, yield_rate_bps: i128, elapsed_seconds: u64) -> i128 {
     let elapsed_i128 = i128::from(elapsed_seconds);
-    principal * yield_rate_bps * elapsed_i128 / (BASIS_POINTS * SECONDS_PER_YEAR as i128)
+    principal * yield_rate_bps * elapsed_i128 / (BASIS_POINTS * i128::from(SECONDS_PER_YEAR))
 }
 
 // ============================================================================

--- a/acbu_savings_vault/tests/test_lock_and_interest.rs
+++ b/acbu_savings_vault/tests/test_lock_and_interest.rs
@@ -35,8 +35,8 @@ const BASIS_POINTS: i128 = 10_000;
 /// Compute the expected yield using the same formula as the contract:
 ///   principal * yield_rate_bps * elapsed_seconds / (BASIS_POINTS * SECONDS_PER_YEAR)
 fn expected_yield(principal: i128, yield_rate_bps: i128, elapsed_seconds: u64) -> i128 {
-    let elapsed = elapsed_seconds as i128;
-    principal * yield_rate_bps * elapsed / (BASIS_POINTS * SECONDS_PER_YEAR as i128)
+    let elapsed = i128::from(elapsed_seconds);
+    principal * yield_rate_bps * elapsed / (BASIS_POINTS * i128::from(SECONDS_PER_YEAR))
 }
 
 struct Harness {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -286,14 +286,14 @@ pub fn median(mut values: soroban_sdk::Vec<i128>) -> Option<i128> {
 
     if n % 2 == 0 {
         // For even count, find two middle elements and average them
-        quickselect_inplace(&mut values, 0, (n - 1) as i32, (mid - 1) as i32);
+        quickselect_inplace(&mut values, 0, i32::try_from(n - 1).unwrap_or(0), i32::try_from(mid - 1).unwrap_or(0));
         let val1 = values.get(mid - 1)?;
-        quickselect_inplace(&mut values, 0, (n - 1) as i32, mid as i32);
+        quickselect_inplace(&mut values, 0, i32::try_from(n - 1).unwrap_or(0), i32::try_from(mid).unwrap_or(0));
         let val2 = values.get(mid)?;
         Some((val1 + val2) / 2)
     } else {
         // For odd count, find the middle element
-        quickselect_inplace(&mut values, 0, (n - 1) as i32, mid as i32);
+        quickselect_inplace(&mut values, 0, i32::try_from(n - 1).unwrap_or(0), i32::try_from(mid).unwrap_or(0));
         Some(values.get(mid)?)
     }
 }
@@ -315,23 +315,23 @@ fn quickselect_inplace(values: &mut soroban_sdk::Vec<i128>, mut left: i32, mut r
 
 /// Partition array in-place for quickselect using Lomuto partition scheme
 fn partition_inplace(values: &mut soroban_sdk::Vec<i128>, left: i32, right: i32) -> i32 {
-    let pivot_value = values.get(right as u32).unwrap_or(0);
+    let pivot_value = values.get(u32::try_from(right).unwrap_or(0)).unwrap_or(0);
     let mut i = left - 1;
 
     for j in left..right {
-        let val_j = values.get(j as u32).unwrap_or(0);
+        let val_j = values.get(u32::try_from(j).unwrap_or(0)).unwrap_or(0);
         if val_j < pivot_value {
             i += 1;
-            let idx_i = i as u32;
-            let idx_j = j as u32;
+            let idx_i = u32::try_from(i).unwrap_or(0);
+            let idx_j = u32::try_from(j).unwrap_or(0);
             let val_i = values.get(idx_i).unwrap_or(0);
             values.set(idx_i, val_j);
             values.set(idx_j, val_i);
         }
     }
 
-    let idx_i_plus_1 = (i + 1) as u32;
-    let idx_right = right as u32;
+    let idx_i_plus_1 = u32::try_from(i + 1).unwrap_or(0);
+    let idx_right = u32::try_from(right).unwrap_or(0);
     let val_i_plus_1 = values.get(idx_i_plus_1).unwrap_or(0);
     values.set(idx_i_plus_1, pivot_value);
     values.set(idx_right, val_i_plus_1);


### PR DESCRIPTION
## Summary

### Commits

1. **#380**: Clarify empty migration functions as intentionally no-op
   - Added explanatory comments to empty `migrate_v0_to_v1` functions in lending pool, oracle, and reserve tracker

2. **#381**: Replace lossy `as` casts with safe `try_from` conversions
   - `fee_rate_bps as u32` → `u32::try_from()` in lending pool
   - `as i32`/ `as u32` casts → `try_from()` in shared median/quickselect
   - `as i128` casts → `i128::from()` in savings vault tests
   - `.len() as u32` → `u32::try_from()` in burning gas estimation test

3. **#382**: Standardize `#[cfg(test)]` module placement
   - Moved inline tests from `acbu_escrow/src/lib.rs` to `tests/test_error_display.rs`
   - Moved unit tests from `acbu_oracle/src/tests.rs` to `tests/test_admin.rs`
   - Removed unused `extern crate alloc` from escrow

4. **#383**: Replace `use super::*` with explicit imports in tests
   - Updated mock modules in all `acbu_minting/tests/` files to use explicit imports

Closes #380, Closes #381, Closes #382, Closes #383
