### PR TITLE
docs: verify no unused storage reads (issue #374)

### DIFF
--- a/docs/issue-374-storage-read-audit.md
+++ b/docs/issue-374-storage-read-audit.md
@@ -1,0 +1,53 @@
+# Audit: Unused Storage Reads (`let _ = env.storage()...get(...)`)
+
+**Issue:** #374 — *"`let _ = env.storage().get::<_, i128>(&key)` for unused storage reads"*
+**Status:** Verified — no occurrences in the codebase.
+**Date:** 2026-06-26
+
+## Background
+
+Issue #374 (from the `ISSUES.md` audit list, item #105) reports that some
+contracts may read a storage value with `let _ = env.storage()...get(...)`. That
+pattern fetches a value at gas cost and then immediately discards it, which
+usually means the developer intended to use the value but forgot. The fix would
+be to either use the value or remove the read.
+
+## Method
+
+The whole workspace was audited for the pattern and for any discarded storage
+read in general:
+
+1. **Discard bindings** — search every Rust file (sources *and* tests) for
+   `let _ = ...`, underscore-prefixed bindings, and the `::<_, i128>` turbofish:
+
+   ```bash
+   grep -rnE 'let[[:space:]]+_' --include='*.rs' .   # excluding target/
+   grep -rn  '::<_, i128>'       --include='*.rs' .   # excluding target/
+   ```
+
+2. **Compiler-detected unused reads** — let the compiler flag any value that is
+   read and never used:
+
+   ```bash
+   cargo check --workspace 2>&1 | grep -iE 'unused_variables|never read'
+   ```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| `let _ = ...` discard bindings | **0 matches** |
+| underscore-prefixed bindings (`let _x = ...`) | **0 matches** |
+| `::<_, i128>` turbofish reads | **0 matches** |
+| `cargo check` unused-read / "never read" warnings | **none** (only an unrelated `unused manifest key: workspace.build` notice) |
+
+Every `env.storage()...get(...)` call in the contracts binds its result to a
+named variable that is subsequently used. The storage-read-then-discard
+anti-pattern described in issue #374 does not occur in any contract.
+
+## Conclusion
+
+There is no live `let _ = ...` storage read to use or remove — the audit item is
+a false positive against the current source. This document records the
+verification so the conclusion is traceable. Should the pattern ever be
+introduced, the searches above reproduce the audit.


### PR DESCRIPTION
# docs: verify no unused storage reads (issue #374)

Closes #374

## Summary

Issue #374 reports that some contracts may read storage values with
`let _ = env.storage().get::<_, i128>(&key)` — fetching a value at gas cost and
then discarding it. I audited the entire workspace and found **no such pattern
present**: there is no live storage read to "use or remove."

This PR adds a short audit document recording the verification, so the
conclusion is traceable and reproducible.

## Investigation

The audited tree is already free of the anti-pattern:

- **No discard bindings.** `grep` across every `.rs` file (sources *and* tests)
  for `let _ = ...`, underscore-prefixed bindings, and the `::<_, i128>`
  turbofish returns **zero matches**:

  ```bash
  $ grep -rnE 'let[[:space:]]+_' --include='*.rs' .   # excluding target/ → no output
  $ grep -rn  '::<_, i128>'       --include='*.rs' .   # excluding target/ → no output
  ```

- **No unused reads per the compiler.** `cargo check --workspace` reports no
  `unused_variables` / "value never read" warnings — only an unrelated
  `unused manifest key: workspace.build` notice. Every `env.storage()...get(...)`
  result is bound to a name that is actually used.

  ```bash
  $ cargo check --workspace 2>&1 | grep -iE 'unused_variables|never read'
  # (no output)
  ```

The storage-read-then-discard anti-pattern described in the issue does not occur
in any contract. The `let _ = env.storage()...` text appears only inside
`ISSUES.md` (the generated audit list, item #105), not in any contract source.

## Change

- `docs/issue-374-storage-read-audit.md` — new audit note documenting the
  method, the search commands, and the results (all clean).

No contract code or CI configuration is changed, because nothing in the source
needs changing.

## Testing

- Reran the grep searches against the current tree → zero matches.
- `cargo check --workspace` → no unused-read warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new audit note documenting the verification results for a storage-read usage check.
  * The report confirms no matching discard-style storage reads were found and no related compiler warnings were surfaced.
  * Includes a repeatable verification approach so the check can be rerun later if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->