### PR TITLE
Docs/issues 369 371 401

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -471,6 +471,10 @@ impl BurningContract {
             .publish((symbol_short!("fee_upd"),), event);
     }
 
+    /// Set the single-currency redemption fee in basis points (admin only).
+    ///
+    /// Reverts if the contract is paused or `fee_bps` is outside `0..=BASIS_POINTS`.
+    /// Emits a `FeeRateUpdatedEvent`.
     pub fn set_fee_single_redeem(env: Env, fee_bps: i128) {
         Self::check_admin(&env);
         Self::check_paused(&env);
@@ -494,10 +498,12 @@ impl BurningContract {
             .publish((symbol_short!("fee_sgl"),), event);
     }
 
+    /// Return the basket redemption fee in basis points.
     pub fn get_fee_rate(env: Env) -> i128 {
         env.storage().instance().get(&DATA_KEY.fee_rate).unwrap()
     }
 
+    /// Return the single-currency redemption fee in basis points.
     pub fn get_fee_single_redeem(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -505,6 +511,7 @@ impl BurningContract {
             .unwrap()
     }
 
+    /// Return `true` if the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()
@@ -514,11 +521,13 @@ impl BurningContract {
 
     // ── Dependency address updaters (admin only) ──────────────────────────
 
+    /// Update the oracle contract address (admin only).
     pub fn update_oracle(env: Env, new_oracle: Address) {
         Self::check_admin(&env);
         env.storage().instance().set(&DATA_KEY.oracle, &new_oracle);
     }
 
+    /// Update the reserve tracker contract address (admin only).
     pub fn update_reserve_tracker(env: Env, new_reserve_tracker: Address) {
         Self::check_admin(&env);
         env.storage()
@@ -526,6 +535,7 @@ impl BurningContract {
             .set(&DATA_KEY.reserve_tracker, &new_reserve_tracker);
     }
 
+    /// Update the ACBU token contract address (admin only).
     pub fn update_acbu_token(env: Env, new_acbu_token: Address) {
         Self::check_admin(&env);
         env.storage()
@@ -533,6 +543,7 @@ impl BurningContract {
             .set(&DATA_KEY.acbu_token, &new_acbu_token);
     }
 
+    /// Update the vault contract address (admin only).
     pub fn update_vault(env: Env, new_vault: Address) {
         Self::check_admin(&env);
         env.storage().instance().set(&DATA_KEY.vault, &new_vault);
@@ -606,14 +617,18 @@ impl BurningContract {
         );
     }
 
+    /// Return the current admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&DATA_KEY.admin).unwrap()
     }
 
+    /// Return the pending admin, if an admin transfer is in progress.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DATA_KEY.pending_admin)
     }
 
+    /// Return the timestamp after which `accept_admin` becomes callable, if a
+    /// transfer is pending.
     pub fn get_pending_admin_eligible_at(env: Env) -> Option<u64> {
         env.storage()
             .instance()
@@ -624,6 +639,7 @@ impl BurningContract {
     // Version / upgrade
     // -----------------------------------------------------------------------
 
+    /// Return the stored contract version (0 if never set).
     pub fn get_version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -631,10 +647,16 @@ impl BurningContract {
             .unwrap_or(0)
     }
 
+    /// Alias for [`Self::get_version`].
     pub fn version(env: Env) -> u32 {
         Self::get_version(env)
     }
 
+    /// Upgrade the contract WASM to `new_wasm_hash` and bump the stored version to
+    /// `new_version` (admin only).
+    ///
+    /// `new_version` must be greater than the current version. Runs any required
+    /// migrations between the old and new versions.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);
         let current_version = Self::get_version(env.clone());

--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -347,18 +347,21 @@ impl Escrow {
         reentrancy_guard::release_guard(&env);
     }
 
+    /// Pause the contract, disabling escrow creation/release/refund (admin only).
     pub fn pause(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &true);
     }
 
+    /// Unpause the contract, re-enabling state-changing operations (admin only).
     pub fn unpause(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &false);
     }
 
+    /// Update the ACBU token contract address (admin only).
     pub fn update_acbu_token(env: Env, new_acbu_token: Address) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -455,6 +458,7 @@ impl Escrow {
             .get(&DATA_KEY.pending_admin_eligible_at)
     }
 
+    /// Return the stored contract version (0 if never set).
     pub fn version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -462,6 +466,8 @@ impl Escrow {
             .unwrap_or(0)
     }
 
+    /// Bump the stored version to the current [`CONTRACT_VERSION`] after a code
+    /// upgrade (admin only). No-op if already at or above the current version.
     pub fn migrate(env: Env) {
         let admin: Address = env
             .storage()
@@ -483,6 +489,9 @@ impl Escrow {
         }
     }
 
+    /// Stage a WASM upgrade to `new_wasm_hash` and start the upgrade timelock
+    /// (admin only). Apply it later with [`Self::execute_upgrade`] once the
+    /// timelock elapses, or abort with [`Self::cancel_upgrade`].
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -495,6 +504,9 @@ impl Escrow {
             .set(&DATA_KEY.pending_upgrade_eligible_at, &eligible_at);
     }
 
+    /// Execute a previously proposed upgrade once its timelock has elapsed,
+    /// swapping in the staged WASM (admin only). Fails if no upgrade is pending or
+    /// the timelock is still active.
     pub fn execute_upgrade(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -518,6 +530,8 @@ impl Escrow {
         env.deployer().update_current_contract_wasm(wasm_hash);
     }
 
+    /// Cancel a pending upgrade, clearing the staged WASM hash and timelock
+    /// (admin only).
     pub fn cancel_upgrade(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -64,6 +64,18 @@ pub struct LoanData {
     pub status: LoanStatus,
 }
 
+/// Emitted when a lender deposits liquidity into the pool.
+///
+/// The `lender` address is carried in the event **payload** (not only the
+/// topic) so off-chain indexers can attribute a deposit to a specific user
+/// without having to parse the originating transaction envelope. See #369.
+#[contractevent]
+pub struct DepositEvent {
+    pub lender: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
 #[contractevent]
 pub struct BorrowEvent {
     pub creator: Address,
@@ -217,8 +229,14 @@ impl LendingPool {
         let token = soroban_sdk::token::Client::new(&env, &acbu_token);
         token.transfer(&lender, &env.current_contract_address(), &amount);
 
-        env.events()
-            .publish((symbol_short!("deposit"), lender), amount);
+        env.events().publish(
+            (symbol_short!("deposit"), lender.clone()),
+            DepositEvent {
+                lender,
+                amount,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
 
         // Release re-entrancy guard
         reentrancy_guard::release_guard(&env);

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -200,6 +200,11 @@ impl LendingPool {
             .set(&SharedDataKey::Version, &VERSION);
     }
 
+    /// Deposit `amount` of ACBU into the pool as the caller's lendable liquidity.
+    ///
+    /// Requires `lender`'s authorization and that the pool is not paused. The
+    /// tokens are pulled from `lender` into the contract and credited to their
+    /// pool balance. `amount` must be positive. Emits a [`DepositEvent`].
     pub fn deposit(env: Env, lender: Address, amount: i128) {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
@@ -242,6 +247,12 @@ impl LendingPool {
         reentrancy_guard::release_guard(&env);
     }
 
+    /// Withdraw `amount` of ACBU from the caller's pool balance.
+    ///
+    /// Requires `lender`'s authorization and that the pool is not paused. Only the
+    /// portion of the balance not currently lent out (balance minus borrowed) may
+    /// be withdrawn. A withdrawal must either drain the balance to zero or leave at
+    /// least [`MIN_POOL_BALANCE`]; otherwise it fails with [`Error::DustBalance`].
     pub fn withdraw(env: Env, lender: Address, amount: i128) {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
@@ -296,6 +307,14 @@ impl LendingPool {
         reentrancy_guard::release_guard(&env);
     }
 
+    /// Borrow `amount` of ACBU against `collateral_amount` from a specific
+    /// `lender`'s liquidity, creating a new loan keyed by `(borrower, loan_id)`.
+    ///
+    /// Requires `borrower`'s authorization and that the pool is not paused. The
+    /// loan must be at least 100% collateralized (`collateral_amount >= amount`)
+    /// and the lender must have enough unborrowed balance. The collateral is
+    /// pulled in before the principal is paid out. `loan_id` must be unique for
+    /// the borrower. Emits [`BorrowEvent`] and [`LoanCreatedEvent`].
     pub fn borrow(
         env: Env,
         borrower: Address,
@@ -417,6 +436,13 @@ impl LendingPool {
         reentrancy_guard::release_guard(&env);
     }
 
+    /// Return the loan identified by `(borrower, loan_id)`, or `None` if it does
+    /// not exist.
+    ///
+    /// For active loans the returned [`LoanData`] is updated in-memory with the
+    /// fee accrued up to the current ledger timestamp (`accrued_interest` and
+    /// `total_repayment_due` are recomputed); the stored loan is not modified.
+    /// Repaid loans are returned as-is.
     pub fn get_loan(env: Env, borrower: Address, loan_id: u64) -> Option<LoanData> {
         let loan_key = LoanId(borrower, loan_id);
         let mut loan_data: LoanData = env.storage().persistent().get(&DataKey::Loan(loan_key))?;
@@ -446,6 +472,13 @@ impl LendingPool {
         Some(loan_data)
     }
 
+    /// Repay `amount` toward the loan `(borrower, loan_id)`.
+    ///
+    /// Requires `borrower`'s authorization and that the pool is not paused.
+    /// `amount` is applied to accrued interest first, then principal, and may not
+    /// exceed the total amount due. When the principal reaches zero the loan is
+    /// marked [`LoanStatus::Repaid`] and the collateral is returned to the
+    /// borrower. Emits [`RepayEvent`], [`RepaymentEvent`] and [`LoanRepaidEvent`].
     pub fn repay(env: Env, borrower: Address, amount: i128, loan_id: u64) {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
@@ -575,16 +608,22 @@ impl LendingPool {
         reentrancy_guard::release_guard(&env);
     }
 
+    /// Pause the pool, disabling deposit/withdraw/borrow/repay. Admin only.
     pub fn pause(env: Env) {
         Self::check_admin(&env);
         env.storage().instance().set(&DataKey::Paused, &true);
     }
 
+    /// Unpause the pool, re-enabling state-changing operations. Admin only.
     pub fn unpause(env: Env) {
         Self::check_admin(&env);
         env.storage().instance().set(&DataKey::Paused, &false);
     }
 
+    /// Stage a WASM upgrade to `new_wasm_hash`/`new_version` and start the upgrade
+    /// timelock. Admin only. `new_version` must exceed the current version. The
+    /// upgrade is applied later via [`Self::execute_upgrade`] once the timelock
+    /// elapses, and can be aborted with [`Self::cancel_upgrade`].
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);
         let current_version: u32 = env
@@ -607,6 +646,10 @@ impl LendingPool {
             .set(&DataKey::PendingUpgradeEligibleAt, &eligible_at);
     }
 
+    /// Execute a previously proposed upgrade once its timelock has elapsed,
+    /// swapping in the new WASM, running any migrations and bumping the stored
+    /// version. Admin only. Fails if no upgrade is pending or the timelock is
+    /// still active.
     pub fn execute_upgrade(env: Env) {
         Self::check_admin(&env);
         let wasm_hash: BytesN<32> = env
@@ -653,6 +696,8 @@ impl LendingPool {
             .set(&SharedDataKey::Version, &new_version);
     }
 
+    /// Cancel a pending upgrade, clearing the staged WASM hash, version and
+    /// timelock. Admin only.
     pub fn cancel_upgrade(env: Env) {
         Self::check_admin(&env);
         env.storage()
@@ -666,6 +711,8 @@ impl LendingPool {
             .remove(&DataKey::PendingUpgradeEligibleAt);
     }
 
+    /// Return the lender's total pool balance (including any amount currently lent
+    /// out), or `0` if they have never deposited.
     pub fn get_balance(env: Env, lender: Address) -> i128 {
         env.storage()
             .persistent()

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -1002,10 +1002,8 @@ impl MintingContract {
         reentrancy_guard::release_guard(&env);
     }
 
-    /// General fiat mint: User/fintech provides fintech_tx_id; operator/backend signs.
-    /// Validates that the request is not duplicated and that rate/reserve checks pass.
-    /// This replaces the previous hardcoded 1:1 minting path with full oracle + reserve validation.
-
+    /// Return the operator address (the key authorized to sign day-to-day mint
+    /// requests). Falls back to the admin address if no separate operator is set.
     pub fn get_operator(env: Env) -> Address {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         env.storage()
@@ -1014,6 +1012,9 @@ impl MintingContract {
             .unwrap_or(admin)
     }
 
+    /// Set the operator address (admin only). The operator must differ from the
+    /// admin to preserve role separation, otherwise it reverts with
+    /// `InvalidRoleSeparation`.
     pub fn set_operator(env: Env, new_operator: Address) {
         Self::check_admin(&env);
         let admin = env.storage().instance().get(&DATA_KEY.admin).unwrap();
@@ -1025,6 +1026,10 @@ impl MintingContract {
             .set(&DATA_KEY.operator, &new_operator);
     }
 
+    /// Overwrite the tracked total ACBU supply with `new_supply` (admin only).
+    ///
+    /// Used to reconcile the contract's supply counter with the actual on-chain
+    /// token supply. Reverts if paused or if `new_supply` exceeds the max supply.
     pub fn sync_supply(env: Env, new_supply: i128) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1035,6 +1040,7 @@ impl MintingContract {
             .set(&DATA_KEY.total_supply, &new_supply);
     }
 
+    /// Return the current tracked total ACBU supply (7 decimals).
     pub fn get_total_supply(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -1042,6 +1048,7 @@ impl MintingContract {
             .unwrap_or(0)
     }
 
+    /// Return the maximum ACBU supply cap (defaults to [`MAX_TOTAL_SUPPLY`]).
     pub fn get_max_supply(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -1049,6 +1056,7 @@ impl MintingContract {
             .unwrap_or(MAX_TOTAL_SUPPLY)
     }
 
+    /// Set the maximum ACBU supply cap (admin only). Reverts if paused.
     pub fn set_max_supply(env: Env, new_max_supply: i128) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1069,18 +1077,24 @@ impl MintingContract {
         }
     }
 
+    /// Pause the contract, disabling all minting operations (admin only).
     pub fn pause(env: Env) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &true);
     }
 
+    /// Unpause the contract, re-enabling minting operations (admin only).
     pub fn unpause(env: Env) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &false);
     }
 
+    /// Set the basket/USDC mint fee in basis points (admin only).
+    ///
+    /// Reverts if paused or `fee_rate_bps` is outside `0..=BASIS_POINTS`. Emits a
+    /// `FeeRateUpdatedEvent`.
     pub fn set_fee_rate(env: Env, fee_rate_bps: i128) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1105,6 +1119,10 @@ impl MintingContract {
             .publish((symbol_short!("fee_upd"),), event);
     }
 
+    /// Set the single-currency mint fee in basis points (admin only).
+    ///
+    /// Reverts if paused or `fee_single_bps` is outside `0..=BASIS_POINTS`. Emits a
+    /// `FeeRateUpdatedEvent`.
     pub fn set_fee_single(env: Env, fee_single_bps: i128) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1129,14 +1147,17 @@ impl MintingContract {
             .publish((symbol_short!("fee_sgl"),), event);
     }
 
+    /// Return the basket/USDC mint fee in basis points.
     pub fn get_fee_rate(env: Env) -> i128 {
         env.storage().instance().get(&DATA_KEY.fee_rate).unwrap()
     }
 
+    /// Return the single-currency mint fee in basis points.
     pub fn get_fee_single(env: Env) -> i128 {
         env.storage().instance().get(&DATA_KEY.fee_single).unwrap()
     }
 
+    /// Return `true` if the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()
@@ -1146,12 +1167,14 @@ impl MintingContract {
 
     // ── Dependency address updaters (admin only) ──────────────────────────
 
+    /// Update the oracle contract address (admin only).
     pub fn update_oracle(env: Env, new_oracle: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.oracle, &new_oracle);
     }
 
+    /// Update the reserve tracker contract address (admin only).
     pub fn update_reserve_tracker(env: Env, new_reserve_tracker: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1160,6 +1183,7 @@ impl MintingContract {
             .set(&DATA_KEY.reserve_tracker, &new_reserve_tracker);
     }
 
+    /// Update the ACBU token contract address (admin only).
     pub fn update_acbu_token(env: Env, new_acbu_token: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1168,12 +1192,14 @@ impl MintingContract {
             .set(&DATA_KEY.acbu_token, &new_acbu_token);
     }
 
+    /// Update the vault contract address (admin only).
     pub fn update_vault(env: Env, new_vault: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.vault, &new_vault);
     }
 
+    /// Update the treasury address that receives collected fees (admin only).
     pub fn update_treasury(env: Env, new_treasury: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1182,6 +1208,7 @@ impl MintingContract {
             .set(&DATA_KEY.treasury, &new_treasury);
     }
 
+    /// Update the USDC token contract address (admin only).
     pub fn update_usdc_token(env: Env, new_usdc_token: Address) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
@@ -1294,6 +1321,7 @@ impl MintingContract {
         }
     }
 
+    /// Return the stored contract version (0 if never set).
     pub fn get_version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -1301,6 +1329,11 @@ impl MintingContract {
             .unwrap_or(0)
     }
 
+    /// Upgrade the contract WASM to `new_wasm_hash` and bump the stored version to
+    /// `new_version` (admin only).
+    ///
+    /// `new_version` must be greater than the current version. Reverts if paused.
+    /// Runs any required migrations between the old and new versions.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();

--- a/acbu_multisig/src/lib.rs
+++ b/acbu_multisig/src/lib.rs
@@ -325,10 +325,13 @@ impl MultisigContract {
     // Read-only helpers
     // -----------------------------------------------------------------------
 
+    /// Return the current multisig configuration (signer list and threshold).
     pub fn get_config(env: Env) -> MultisigConfig {
         Self::load_config(&env)
     }
 
+    /// Return the proposal identified by `proposal_id`, panicking with
+    /// `ProposalNotFound` if it does not exist.
     pub fn get_proposal(env: Env, proposal_id: u64) -> AdminProposal {
         env.storage()
             .instance()
@@ -336,10 +339,12 @@ impl MultisigContract {
             .unwrap_or_else(|| env.panic_with_error(Error::ProposalNotFound))
     }
 
+    /// Return the id that will be assigned to the next created proposal.
     pub fn get_next_id(env: Env) -> u64 {
         env.storage().instance().get(&DataKey::NextId).unwrap_or(0)
     }
 
+    /// Return `true` if `address` is one of the configured signers.
     pub fn is_signer(env: Env, address: Address) -> bool {
         let config = Self::load_config(&env);
         for s in config.signers.iter() {
@@ -350,6 +355,8 @@ impl MultisigContract {
         false
     }
 
+    /// Return the number of approvals recorded for `proposal_id`, panicking with
+    /// `ProposalNotFound` if it does not exist.
     pub fn approval_count(env: Env, proposal_id: u64) -> u32 {
         let proposal: AdminProposal = env
             .storage()
@@ -359,6 +366,7 @@ impl MultisigContract {
         proposal.approvals.len()
     }
 
+    /// Return the stored contract version (0 if never set).
     pub fn version(env: Env) -> u32 {
         env.storage()
             .instance()

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -171,6 +171,13 @@ impl OracleContract {
     // Initialisation
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Initialize the oracle. Callable once; reverts with `AlreadyInitialized`
+    /// afterwards.
+    ///
+    /// Sets the `admin`, the initial `validators` set and the `min_signatures`
+    /// threshold required to accept a rate update, the supported `currencies`, and
+    /// their `basket_weights`. `min_signatures` must be in `1..=validators.len()`
+    /// and the validator count must not exceed [`MAX_VALIDATORS`].
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -234,6 +241,8 @@ impl OracleContract {
     // Two-step admin rotation
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Step 1 of admin rotation — current admin nominates `new_admin` and starts
+    /// the timelock. Admin only. Emits `AdminTransferInitiatedEvent`.
     pub fn transfer_admin(env: Env, new_admin: Address) {
         Self::check_admin(&env);
 
@@ -256,6 +265,9 @@ impl OracleContract {
         );
     }
 
+    /// Step 2 of admin rotation — the nominated address claims ownership after the
+    /// timelock elapses. Requires the pending admin's auth. Emits
+    /// `AdminTransferCompletedEvent`.
     pub fn accept_admin(env: Env) {
         let pending_admin: Address = match env.storage().instance().get(&DATA_KEY.pending_admin) {
             Some(a) => a,
@@ -294,6 +306,8 @@ impl OracleContract {
         );
     }
 
+    /// Cancel a pending admin transfer (current admin only). Emits
+    /// `AdminTransferCancelledEvent`.
     pub fn cancel_admin_transfer(env: Env) {
         Self::check_admin(&env);
 
@@ -318,14 +332,18 @@ impl OracleContract {
         );
     }
 
+    /// Return the current admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&DATA_KEY.admin).unwrap()
     }
 
+    /// Return the pending admin, if a transfer is in progress.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DATA_KEY.pending_admin)
     }
 
+    /// Return the timestamp after which `accept_admin` becomes callable, if a
+    /// transfer is pending.
     pub fn get_pending_admin_eligible_at(env: Env) -> Option<u64> {
         env.storage()
             .instance()
@@ -336,6 +354,16 @@ impl OracleContract {
     // Rate management
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Submit a rate update for `currency` from an authorized `validator`.
+    ///
+    /// Requires the validator's auth and that it is in the active validator set.
+    /// `sources` are the raw per-feed rates: when more than one is supplied the
+    /// median is taken and feeds deviating beyond [`OUTLIER_THRESHOLD_BPS`] are
+    /// discarded as outliers (emitting `OutlierDetectionEvent`). Updates are
+    /// rate-limited to the configured update interval unless the new rate deviates
+    /// beyond [`EMERGENCY_THRESHOLD_BPS`]. Rejects timestamps older than the stored
+    /// rate. The `_timestamp` parameter is ignored; the ledger timestamp is used.
+    /// Emits `RateUpdateEvent`.
     pub fn update_rate(
         env: Env,
         validator: Address,
@@ -460,6 +488,11 @@ impl OracleContract {
         env.events().publish((symbol_short!("rate_upd"),), event);
     }
 
+    /// Admin override to set the rate for `currency` directly, bypassing validator
+    /// consensus, the update interval and outlier checks (admin only).
+    ///
+    /// Intended for emergencies. `rate` must be positive and may not roll the
+    /// timestamp backwards. Emits `RateUpdateEvent`.
     pub fn set_rate_admin(env: Env, currency: CurrencyCode, rate: i128) {
         Self::check_admin(&env);
         if rate <= 0 {
@@ -501,6 +534,10 @@ impl OracleContract {
         env.events().publish((symbol_short!("rate_upd"),), event);
     }
 
+    /// Return the latest USD rate (7 decimals) for `currency`.
+    ///
+    /// Panics if the currency is not registered, has no rate yet, or the stored
+    /// rate is stale (older than [`STALE_RATE_MAX_LEDGERS`]).
     pub fn get_rate(env: Env, currency: CurrencyCode) -> i128 {
         Self::assert_currency_registered(&env, &currency);
         if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
@@ -511,6 +548,8 @@ impl OracleContract {
         }
     }
 
+    /// Like [`Self::get_rate`] but also returns the timestamp at which the rate was
+    /// recorded, as `(rate, timestamp)`.
     pub fn get_rate_with_timestamp(env: Env, currency: CurrencyCode) -> (i128, u64) {
         Self::assert_currency_registered(&env, &currency);
         if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
@@ -521,6 +560,12 @@ impl OracleContract {
         }
     }
 
+    /// Compute the basket-weighted ACBU/USD rate together with the oldest
+    /// contributing rate timestamp, as `(rate, oldest_timestamp)`.
+    ///
+    /// Iterates the configured currencies, weights each fresh rate by its basket
+    /// weight and normalizes by total weight. Panics if no currencies are
+    /// configured or no fresh rates contribute.
     pub fn get_acbu_usd_rate_with_timestamp(env: Env) -> (i128, u64) {
         let basket_weights: Map<CurrencyCode, i128> = env
             .storage()
@@ -570,6 +615,11 @@ impl OracleContract {
         )
     }
 
+    /// Compute the basket-weighted ACBU/USD rate (7 decimals).
+    ///
+    /// Same computation as [`Self::get_acbu_usd_rate_with_timestamp`] without the
+    /// timestamp. Panics if no currencies are configured or no fresh rates
+    /// contribute.
     pub fn get_acbu_usd_rate(env: Env) -> i128 {
         let basket_weights: Map<CurrencyCode, i128> = env
             .storage()
@@ -610,6 +660,7 @@ impl OracleContract {
     // Basket / token config
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Return the list of currencies that make up the basket.
     pub fn get_currencies(env: Env) -> Vec<CurrencyCode> {
         env.storage()
             .instance()
@@ -617,6 +668,8 @@ impl OracleContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Return the basket weight (in basis points) for `currency`, or `0` if it has
+    /// no configured weight.
     pub fn get_basket_weight(env: Env, currency: CurrencyCode) -> i128 {
         let basket_weights: Map<CurrencyCode, i128> = env
             .storage()
@@ -626,6 +679,7 @@ impl OracleContract {
         basket_weights.get(currency).unwrap_or(0)
     }
 
+    /// Replace the basket currency list and their weights (admin only).
     pub fn set_basket_config(
         env: Env,
         currencies: Vec<CurrencyCode>,
@@ -640,6 +694,7 @@ impl OracleContract {
             .set(&DATA_KEY.basket_weights, &basket_weights);
     }
 
+    /// Set the S-token contract address backing `currency` (admin only).
     pub fn set_s_token_address(env: Env, currency: CurrencyCode, token_address: Address) {
         Self::check_admin(&env);
         let mut m: Map<CurrencyCode, Address> = env
@@ -651,6 +706,8 @@ impl OracleContract {
         env.storage().instance().set(&DATA_KEY.s_tokens, &m);
     }
 
+    /// Return the S-token contract address backing `currency`, panicking with
+    /// `STokenNotConfigured` if none is set.
     pub fn get_s_token_address(env: Env, currency: CurrencyCode) -> Address {
         let m: Map<CurrencyCode, Address> = env
             .storage()
@@ -668,6 +725,11 @@ impl OracleContract {
     // Validator management
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Schedule adding (`add = true`) or removing (`add = false`) `validator` from
+    /// the validator set, starting the timelock (admin only).
+    ///
+    /// The change is applied later via [`Self::execute_validator_change`] once the
+    /// timelock elapses, or aborted with [`Self::cancel_validator_change`].
     pub fn schedule_validator_change(env: Env, validator: Address, add: bool) {
         Self::check_admin(&env);
         let eligible_at = env.ledger().timestamp() + ADMIN_TIMELOCK_SECONDS;
@@ -682,6 +744,13 @@ impl OracleContract {
             .set(&DATA_KEY.pending_validator_eligible_at, &eligible_at);
     }
 
+    /// Apply a previously scheduled validator add/remove once its timelock has
+    /// elapsed (admin only).
+    ///
+    /// Adding rejects duplicates and enforces [`MAX_VALIDATORS`]; removing refuses
+    /// to drop below `min_signatures` and clears all stored rates so no submission
+    /// from the removed validator persists. Panics if no change is pending or the
+    /// timelock is still active.
     pub fn execute_validator_change(env: Env) {
         Self::check_admin(&env);
         let validator: Address = match env.storage().instance().get(&DATA_KEY.pending_validator) {
@@ -769,6 +838,8 @@ impl OracleContract {
             .set(&DATA_KEY.validator_set, &validator_set);
     }
 
+    /// Cancel a pending validator change, clearing the staged validator and
+    /// timelock (admin only).
     pub fn cancel_validator_change(env: Env) {
         Self::check_admin(&env);
         env.storage().instance().remove(&DATA_KEY.pending_validator);
@@ -780,10 +851,12 @@ impl OracleContract {
             .remove(&DATA_KEY.pending_validator_eligible_at);
     }
 
+    /// Return the current list of validators.
     pub fn get_validators(env: Env) -> Vec<Address> {
         env.storage().instance().get(&DATA_KEY.validators).unwrap()
     }
 
+    /// Return the number of validator signatures required to accept a rate update.
     pub fn get_min_signatures(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -791,6 +864,7 @@ impl OracleContract {
             .unwrap()
     }
 
+    /// Return the number of decimal places used for all rates (always 7).
     pub fn get_rate_decimals(env: Env) -> u32 {
         7
     }
@@ -799,6 +873,7 @@ impl OracleContract {
     // Upgrade / migration
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Return the stored contract version (0 if never set).
     pub fn get_version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -806,6 +881,8 @@ impl OracleContract {
             .unwrap_or(0)
     }
 
+    /// Run storage migrations up to the current [`VERSION`] and bump the stored
+    /// version (admin only). No-op if already current.
     pub fn migrate(env: Env) {
         Self::check_admin(&env);
         let current_version = VERSION;
@@ -847,6 +924,10 @@ impl OracleContract {
         }
     }
 
+    /// Stage a WASM upgrade to `new_wasm_hash`/`new_version` and start the upgrade
+    /// timelock (admin only). `new_version` must exceed the current version. Apply
+    /// it later with [`Self::execute_upgrade`] or abort with
+    /// [`Self::cancel_upgrade`].
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);
         let current_version = Self::get_version(env.clone());
@@ -865,6 +946,9 @@ impl OracleContract {
             .set(&DATA_KEY.pending_upgrade_eligible_at, &eligible_at);
     }
 
+    /// Execute a previously proposed upgrade once its timelock has elapsed,
+    /// swapping in the staged WASM, running migrations and bumping the version
+    /// (admin only). Panics if none is pending or the timelock is still active.
     pub fn execute_upgrade(env: Env) {
         Self::check_admin(&env);
         let wasm_hash: BytesN<32> =
@@ -907,6 +991,8 @@ impl OracleContract {
             .set(&SharedDataKey::Version, &new_version);
     }
 
+    /// Cancel a pending upgrade, clearing the staged WASM hash, version and
+    /// timelock (admin only).
     pub fn cancel_upgrade(env: Env) {
         Self::check_admin(&env);
         env.storage()

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -104,6 +104,8 @@ impl ReserveTrackerContract {
             .set(&SharedDataKey::Version, &CONTRACT_VERSION);
     }
 
+    /// Return the circulating ACBU total supply by cross-contract-calling
+    /// `get_total_supply` on the registered ACBU token contract.
     pub fn get_total_supply_from_token(env: &Env) -> i128 {
         let acbu_token_addr: Address = env.storage().instance().get(&DATA_KEY.acbu_token).unwrap();
         // Use invoke_contract to avoid dependency on a specific token client implementation
@@ -129,6 +131,9 @@ impl ReserveTrackerContract {
         Self::is_reserve_sufficient(env, total_acbu_supply)
     }
 
+    /// Like [`Self::verify_reserves`] but uses the caller-supplied
+    /// `total_acbu_supply` instead of querying the token contract. Returns `true`
+    /// if reserves meet the minimum ratio.
     pub fn verify_reserves_manual(env: Env, total_acbu_supply: i128) -> bool {
         Self::is_reserve_sufficient(env, total_acbu_supply)
     }
@@ -189,6 +194,12 @@ impl ReserveTrackerContract {
         total_usd
     }
 
+    /// Return `true` if total reserve USD value backs `total_acbu_supply` at or
+    /// above the configured minimum reserve ratio (default 100%).
+    ///
+    /// Sums the USD value of all stored reserves and compares it against the ACBU
+    /// supply valued at the oracle's ACBU/USD rate. Trivially returns `true` when
+    /// supply is non-positive or values to zero.
     pub fn is_reserve_sufficient(env: Env, total_acbu_supply: i128) -> bool {
         if total_acbu_supply <= 0 {
             return true;
@@ -225,6 +236,9 @@ impl ReserveTrackerContract {
         current_ratio >= min_reserve_ratio
     }
 
+    /// Upgrade the contract WASM to `new_wasm_hash` and bump the stored version to
+    /// `new_version` (admin only). `new_version` must exceed the current version.
+    /// Runs any required migrations.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);
 
@@ -273,11 +287,13 @@ impl ReserveTrackerContract {
     // Dependency address updaters (admin only)
     // -----------------------------------------------------------------------
 
+    /// Update the oracle contract address (admin only).
     pub fn update_oracle(env: Env, new_oracle: Address) {
         Self::check_admin(&env);
         env.storage().instance().set(&DATA_KEY.oracle, &new_oracle);
     }
 
+    /// Update the ACBU token contract address (admin only).
     pub fn update_acbu_token(env: Env, new_acbu_token: Address) {
         Self::check_admin(&env);
         env.storage()

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -192,6 +192,12 @@ impl SavingsVault {
     // Public logic
     // -----------------------------------------------------------------------
 
+    /// Initialize the vault. Callable once; reverts with `AlreadyInitialized`
+    /// afterwards.
+    ///
+    /// Sets the `admin`, the `acbu_token` accepted for deposits, the deposit
+    /// `fee_rate_bps` and the `yield_rate_bps` paid on locked deposits. Both rates
+    /// must be within `0..=BASIS_POINTS`. The vault starts unpaused.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -419,6 +425,8 @@ impl SavingsVault {
         payout_amount
     }
 
+    /// Return the total locked principal `user` holds across all deposit lots for
+    /// the given `term_seconds` bucket (0 if none).
     pub fn get_balance(env: Env, user: Address, term_seconds: u64) -> i128 {
         let key = (DEPOSIT_KEY, user, term_seconds);
         let lots: Vec<DepositLot> = env
@@ -429,6 +437,9 @@ impl SavingsVault {
         Self::sum_lots(&lots)
     }
 
+    /// Return the yield accrued so far on `user`'s matured deposit lots for the
+    /// given `term_seconds`. Only lots past their unlock time contribute. Panics
+    /// with `NoDeposit` if the user has no lots in this bucket.
     pub fn get_pending_yield(env: Env, user: Address, term_seconds: u64) -> i128 {
         let key = (DEPOSIT_KEY, user, term_seconds);
         let lots: Vec<DepositLot> = env
@@ -481,18 +492,21 @@ impl SavingsVault {
         ends
     }
 
+    /// Pause the vault, disabling deposits and withdrawals (admin only).
     pub fn pause(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &true);
     }
 
+    /// Unpause the vault, re-enabling deposits and withdrawals (admin only).
     pub fn unpause(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
         env.storage().instance().set(&DATA_KEY.paused, &false);
     }
 
+    /// Update the ACBU token contract address (admin only).
     pub fn update_acbu_token(env: Env, new_acbu_token: Address) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -501,6 +515,8 @@ impl SavingsVault {
             .set(&DATA_KEY.acbu_token, &new_acbu_token);
     }
 
+    /// Set the deposit fee in basis points (admin only). Must be within
+    /// `0..=BASIS_POINTS`.
     pub fn set_fee_rate(env: Env, fee_rate_bps: i128) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -512,6 +528,8 @@ impl SavingsVault {
             .set(&DATA_KEY.fee_rate, &fee_rate_bps);
     }
 
+    /// Set the yield rate in basis points paid on locked deposits (admin only).
+    /// Must be within `0..=BASIS_POINTS`.
     pub fn set_yield_rate(env: Env, yield_rate_bps: i128) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -523,10 +541,12 @@ impl SavingsVault {
             .set(&DATA_KEY.yield_rate, &yield_rate_bps);
     }
 
+    /// Return the current admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&DATA_KEY.admin).unwrap()
     }
 
+    /// Return the stored contract version (0 if never set).
     pub fn get_version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -534,6 +554,9 @@ impl SavingsVault {
             .unwrap_or(0)
     }
 
+    /// Stage a WASM upgrade to `new_wasm_hash`/`new_version` and start the upgrade
+    /// timelock (admin only). `new_version` must exceed the current version. Apply
+    /// later with [`Self::execute_upgrade`] or abort with [`Self::cancel_upgrade`].
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -558,6 +581,9 @@ impl SavingsVault {
             .set(&DATA_KEY.pending_upgrade_eligible_at, &eligible_at);
     }
 
+    /// Execute a previously proposed upgrade once its timelock has elapsed,
+    /// swapping in the staged WASM, running migrations and bumping the version
+    /// (admin only). Panics if none is pending or the timelock is still active.
     pub fn execute_upgrade(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -601,6 +627,8 @@ impl SavingsVault {
             .set(&SharedDataKey::Version, &new_version);
     }
 
+    /// Cancel a pending upgrade, clearing the staged WASM hash, version and
+    /// timelock (admin only).
     pub fn cancel_upgrade(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -619,6 +647,8 @@ impl SavingsVault {
     // Two-step admin rotation
     // -----------------------------------------------------------------------
 
+    /// Step 1 of admin rotation — current admin nominates `new_admin` and starts
+    /// the timelock (admin only). Emits an `adm_init` event.
     pub fn transfer_admin(env: Env, new_admin: Address) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -640,6 +670,9 @@ impl SavingsVault {
         );
     }
 
+    /// Step 2 of admin rotation — the nominated address claims ownership after the
+    /// timelock elapses. Requires the pending admin's auth. Emits an `adm_done`
+    /// event.
     pub fn accept_admin(env: Env) {
         let pending_admin: Address = env
             .storage()
@@ -670,6 +703,8 @@ impl SavingsVault {
         );
     }
 
+    /// Cancel a pending admin transfer (current admin only). Emits an `adm_cncl`
+    /// event.
     pub fn cancel_admin_transfer(env: Env) {
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         admin.require_auth();
@@ -688,10 +723,12 @@ impl SavingsVault {
         );
     }
 
+    /// Return the pending admin, if a transfer is in progress.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DATA_KEY.pending_admin)
     }
 
+    /// Return the stored contract version (0 if never set).
     pub fn version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -699,6 +736,8 @@ impl SavingsVault {
             .unwrap_or(0)
     }
 
+    /// Return the timestamp after which `accept_admin` becomes callable, if a
+    /// transfer is pending.
     pub fn get_pending_admin_eligible_at(env: Env) -> Option<u64> {
         env.storage()
             .instance()

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -204,22 +204,47 @@ pub struct OutlierDetectionEvent {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum ContractError {
+    /// The caller is not authorized for this action (e.g. not the admin/operator,
+    /// or `require_auth` was not satisfied).
     Unauthorized = 1,
+    /// The contract is paused; state-changing operations are temporarily disabled.
     Paused = 2,
+    /// The supplied amount is invalid (non-positive, or outside the allowed bounds
+    /// such as min/max mint or burn limits).
     InvalidAmount = 3,
+    /// The exchange/conversion rate is invalid (e.g. zero, negative, or rejected
+    /// by outlier/deviation checks).
     InvalidRate = 4,
+    /// Reserves are insufficient to back the requested mint/operation against the
+    /// configured collateralization requirement.
     InsufficientReserves = 5,
+    /// The per-window operation rate limit has been exceeded; retry later.
     RateLimitExceeded = 6,
+    /// The currency code is not recognized or not registered in the oracle/basket.
     InvalidCurrency = 7,
+    /// A cross-contract call to the oracle failed or returned an unusable result
+    /// (e.g. missing or stale rate).
     OracleError = 8,
+    /// A cross-contract call to the reserve tracker failed or returned an
+    /// unusable result.
     ReserveError = 9,
+    /// The account's token balance is too low to complete the transfer/operation.
     InsufficientBalance = 10,
+    /// The recipient address is invalid for this operation (e.g. a contract
+    /// address where a classic account is required).
     InvalidRecipient = 11,
     /// WASM upgrade rejected: `new_version` must be greater than the stored version.
     InvalidVersion = 12,
+    /// No admin transfer is in progress, so `accept_admin` has nothing to claim.
     NoPendingAdmin = 13,
+    /// The two-step admin transfer timelock has not yet elapsed; the pending admin
+    /// must wait before calling `accept_admin`.
     AdminTimelockNotElapsed = 14,
+    /// No admin transfer is in progress, so `cancel_admin_transfer` has nothing to
+    /// cancel.
     NoPendingAdminToCancel = 15,
+    /// Catch-all for an unexpected/unclassified failure. Should not occur in normal
+    /// operation; treat as an internal error.
     Unknown = 9999,
 }
 


### PR DESCRIPTION
# docs: add inline documentation & emit lender in deposit event

Closes #369 
Closes #371 
Closes #401 

## Summary

This PR is documentation-focused and improves the developer/integrator
experience for the ACBU contracts, plus one small event-payload fix so
off-chain indexers can attribute deposits without parsing the raw
transaction envelope.

Branch: `docs/issues-369-371-401`

## Changes

### #369 — Lending pool deposit event missing lender field
`acbu_lending_pool/src/lib.rs`

- Added a structured `DepositEvent { lender, amount, timestamp }`
  (`#[contractevent]`), mirroring the existing `BorrowEvent` /
  `LoanCreatedEvent` pattern in the same contract.
- `deposit` now publishes this event so the **lender address is carried in
  the event payload** (not only the topic). Off-chain balance tracking can
  attribute a deposit to a specific user directly from the event data
  instead of decoding the transaction envelope.

### #371 — `shared::ContractError` variants undocumented
`shared/src/lib.rs`

- Added `///` docstrings to every variant of the `ContractError` enum,
  describing what each error means and when it is returned. Client
  developers no longer need to read contract source to interpret error
  codes (the numeric codes remain stable).

### #401 — `#[contractimpl]` functions lack inline documentation
Multiple contracts

- Added `///` doc comments to the public-facing contract functions that
  were missing them, covering parameters, behavior, authorization
  requirements (admin/operator/validator), and emitted events. These flow
  through to SDK-generated docs so function signatures are self-explanatory.
- Contracts updated: `acbu_lending_pool`, `acbu_burning`, `acbu_escrow`,
  `acbu_minting`, `acbu_multisig`, `acbu_oracle`, `acbu_reserve_tracker`,
  `acbu_savings_vault`.
- While documenting `acbu_minting::get_operator`, replaced a misattributed
  doc block (a leftover "general fiat mint" description sitting above
  `get_operator`) with an accurate description of the function.

## Notes

- These changes are non-functional aside from the `DepositEvent` payload in
  #369: the rest are doc comments only and do not alter contract logic,
  storage layout, or ABI of existing functions.
- No new dependencies; no changes to `Cargo.toml`.

## Commits

- `fix(#369,#371): emit lender in deposit event; document ContractError variants`
- `docs(#401): document public functions in lending_pool, burning, escrow`
- `docs(#401): document public functions in minting contract`
- `docs(#401): document public functions in oracle and multisig`
- `docs(#401): document public functions in reserve_tracker and savings_vault`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured deposit event details in the lending pool, including lender, amount, and timestamp.

* **Documentation**
  * Expanded public contract docs across multiple modules for fees, pausing, admin changes, upgrades, balance checks, reserve verification, and vault/lending workflows.
  * Clarified read-only helper behavior and error conditions in multisig and shared error descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->