### PR TITLE
test: add should_panic regressions for escrow error paths

### DIFF
--- a/acbu_escrow/tests/test_edge_cases.rs
+++ b/acbu_escrow/tests/test_edge_cases.rs
@@ -27,6 +27,45 @@ fn mint(env: &Env, token: &Address, recipient: &Address, amount: i128) {
     soroban_sdk::token::StellarAssetClient::new(env, token).mint(recipient, &amount);
 }
 
+#[test]
+#[should_panic(expected = "Error(Contract, #3002)")]
+fn test_create_zero_amount_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _token, _cid, client) = setup(&env);
+    let payer = Address::generate(&env);
+    let payee = Address::generate(&env);
+
+    client.create(&payer, &payee, &0i128, &1u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3017)")]
+fn test_create_self_escrow_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, acbu_token, _cid, client) = setup(&env);
+    let payer = Address::generate(&env);
+    let amount = 10_000_000i128;
+
+    mint(&env, &acbu_token, &payer, amount);
+    client.create(&payer, &payer, &amount, &2u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3003)")]
+fn test_release_missing_escrow_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, _token, _cid, client) = setup(&env);
+    let payer = Address::generate(&env);
+
+    client.release(&7u64, &payer);
+}
+
 // ── Create edge cases ─────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- add explicit `#[should_panic]` regression tests for escrow error conditions
- cover invalid amount, self-escrow, and missing escrow release paths

## Why
This addresses issue #398 by ensuring error conditions are exercised directly rather than only validating the success path.

## Changes
- added panic-based tests for zero-amount escrow creation
- added panic-based tests for self-escrow creation
- added panic-based tests for releasing a missing escrow

## Testing
- Local Rust test execution could not be run in this environment because the Cargo/Rust toolchain is not available.
- Please run:
  `cargo test -p acbu_escrow --test test_edge_cases`
  
  Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added edge-case coverage for escrow actions to verify expected errors when creating an escrow with a zero amount, attempting self-escrow, or releasing a non-existent escrow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->