### PR TITLE
 Add rustfmt.toml for workspace-wide formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,148 @@
+# Rustfmt configuration for ACBU smart contract workspace
+# This ensures consistent formatting across all developers
+
+# Maximum line width
+max_width = 100
+
+# Hard tabs or spaces
+hard_tabs = false
+tab_spaces = 4
+
+# Newline style
+newline_style = "Unix"
+
+# Use field init shorthand if possible
+use_field_init_shorthand = true
+
+# Use try shorthand
+use_try_shorthand = true
+
+# Force explicit types in public items
+# public_item_fields = false  # Disabled to allow inference where sensible
+
+# Format comments
+comment_width = 100
+wrap_comments = true
+normalize_comments = true
+normalize_doc_attributes = true
+
+# Imports
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+
+# Structs and enums
+struct_field_align_threshold = 0
+enum_discrim_align_threshold = 0
+
+# Match expressions
+match_arm_blocks = true
+match_arm_leading_pipes = "Never"
+
+# Chains
+chain_width = 60
+
+# Control flow
+single_line_if_else_max_width = 50
+
+# Arrays
+array_width = 60
+
+# Error messages
+error_on_line_overflow = false
+error_on_unformatted = false
+
+# Edition
+edition = "2021"
+
+# Merge derives
+merge_derives = true
+
+# Remove nested parens
+remove_nested_parens = true
+
+# Reorder impl items
+reorder_impl_items = true
+
+# Skip children
+# skip_children = false
+
+# Space after colon
+space_after_colon = true
+space_before_colon = false
+
+# Spaces around ranges
+spaces_around_ranges = false
+
+# Trailing comma
+trailing_comma = "Vertical"
+trailing_semicolon = true
+
+# Type punctuation density
+type_punctuation_density = "Wide"
+
+# Blank lines
+blank_lines_upper_bound = 1
+blank_lines_lower_bound = 0
+
+# Brace style
+brace_style = "SameLineWhere"
+
+# Control brace style
+control_brace_style = "AlwaysSameLine"
+
+# Empty item single line
+empty_item_single_line = true
+
+# Fn args layout
+fn_args_layout = "Tall"
+
+# Fn call width
+fn_call_width = 80
+
+# Fn single line
+fn_single_line = false
+
+# Where single line
+where_single_line = false
+
+# Indent style
+indent_style = "Block"
+
+# Format strings
+format_strings = true
+
+# Format macro matchers
+format_macro_matchers = true
+format_macro_bodies = true
+
+# Hex literal case
+hex_literal_case = "Lower"
+
+# Overflow delimited expr
+overflow_delimited_expr = true
+
+# Preserve block start blank lines
+preserve_block_start_blank_lines = false
+
+# Preserve closure block formatting
+preserve_closure_blockFormatting = false
+
+# Reorder modules
+reorder_modules = true
+
+# Report fixme
+report_fixme = "Always"
+report_todo = "Always"
+
+# Short array element width threshold
+short_array_element_width_threshold = 10
+
+# Struct lit single line
+struct_lit_single_line = true
+
+# Struct variant width
+struct_variant_width = 35
+
+# Condense wildcard suffixes
+condense_wildcard_suffixes = true


### PR DESCRIPTION
Added rustfmt.toml configuration to ensure consistent code formatting across all developers. This eliminates diff noise from style differences and reduces code review time on formatting nits.

closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a repository-wide Rust formatting configuration to standardize code style, line width, indentation, import handling, spacing, and brace placement.
  * Enabled consistent formatting for comments, strings, macros, and multiline expressions.
  * Improved formatting checks by flagging TODO/FIXME markers during formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->