### PR TITLE
feat: Yield paid from contract balance with no external funding source

### DIFF
--- a/acbu_burning/Cargo.toml
+++ b/acbu_burning/Cargo.toml
@@ -14,3 +14,6 @@ shared = { path = "../shared" }
 [dev-dependencies]
 proptest = "1.11.0"
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -5,6 +5,12 @@ use soroban_sdk::{
 };
 
 use shared::{
+    calculate_fee, reentrancy_guard, BurnEvent, ContractError, ContractPhase, CurrencyCode,
+    DataKey as SharedDataKey, BASIS_POINTS, CONTRACT_VERSION, MIN_BURN_AMOUNT,
+    ORACLE_GET_ACBU_RATE_WITH_TS, ORACLE_GET_BASKET_WEIGHT, ORACLE_GET_CURRENCIES,
+    ORACLE_GET_RATE_WITH_TS, ORACLE_GET_S_TOKEN_ADDR, RESERVE_IS_SUFFICIENT,
+    TOKEN_GET_TOTAL_SUPPLY, UPDATE_INTERVAL_SECONDS,
+};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -463,7 +469,7 @@ impl BurningContract {
 
         for v in current_version..new_version {
             if v == 0 {
-                migrate_v0_to_v1(env.clone());
+                shared::migrate_v0_to_v1(&env);
             }
         }
         env.storage()
@@ -510,8 +516,4 @@ impl BurningContract {
             env.panic_with_error(ContractError::InvalidRecipient);
         }
     }
-}
-
-fn migrate_v0_to_v1(_env: Env) {
-    // No storage schema changes between v0 and v1.
 }

--- a/acbu_escrow/Cargo.toml
+++ b/acbu_escrow/Cargo.toml
@@ -13,3 +13,6 @@ shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_lending_pool/Cargo.toml
+++ b/acbu_lending_pool/Cargo.toml
@@ -14,3 +14,6 @@ shared = { path = "../shared" }
 [dev-dependencies]
 proptest = "1.11.0"
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -687,7 +687,7 @@ impl LendingPool {
         env.deployer().update_current_contract_wasm(wasm_hash);
         for v in current_version..new_version {
             match v {
-                0 => migrate_v0_to_v1(env.clone()),
+                0 => shared::migrate_v0_to_v1(&env),
                 _ => {}
             }
         }
@@ -897,8 +897,4 @@ impl LendingPool {
             .and_then(|v| v.checked_div(divisor))
             .unwrap_or_else(|| env.panic_with_error(Error::InvalidAmount))
     }
-}
-
-fn migrate_v0_to_v1(_env: Env) {
-    // No storage schema changes between v0 and v1.
 }

--- a/acbu_minting/Cargo.toml
+++ b/acbu_minting/Cargo.toml
@@ -15,3 +15,6 @@ shared = { path = "../shared" }
 proptest = "1.11.0"
 soroban-sdk = { workspace = true, features = ['testutils'] }
 serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -1359,7 +1359,7 @@ impl MintingContract {
         // Run migrations — the match will gain new arms as versions are added.
         for v in current_version..new_version {
             match v {
-                0 => migrate_v0_to_v1(env.clone()),
+                0 => shared::migrate_v0_to_v1(&env),
                 _ => {}
             }
         }
@@ -1368,10 +1368,6 @@ impl MintingContract {
             .instance()
             .set(&SharedDataKey::Version, &new_version);
     }
-}
-
-fn migrate_v0_to_v1(_env: Env) {
-    // No storage schema changes between v0 and v1.
 }
 
 // Helper functions for proof tracking and validation

--- a/acbu_oracle/Cargo.toml
+++ b/acbu_oracle/Cargo.toml
@@ -13,3 +13,6 @@ shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -982,7 +982,7 @@ impl OracleContract {
         env.deployer().update_current_contract_wasm(wasm_hash);
         for v in current_version..new_version {
             match v {
-                0 => migrate_v0_to_v1(env.clone()),
+                0 => shared::migrate_v0_to_v1(&env),
                 _ => {}
             }
         }
@@ -1054,7 +1054,4 @@ impl OracleContract {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
     }
-}
-fn migrate_v0_to_v1(_env: Env) {
-    // No storage schema changes between v0 and v1.
 }

--- a/acbu_reserve_tracker/Cargo.toml
+++ b/acbu_reserve_tracker/Cargo.toml
@@ -13,3 +13,6 @@ shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -275,7 +275,7 @@ impl ReserveTrackerContract {
         // Run migrations
         for v in current_version..new_version {
             match v {
-                0 => migrate_v0_to_v1(env.clone()),
+                0 => shared::migrate_v0_to_v1(&env),
                 _ => {}
             }
         }
@@ -432,8 +432,4 @@ impl ReserveTrackerContract {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
     }
-}
-
-fn migrate_v0_to_v1(_env: Env) {
-    // No storage schema changes between v0 and v1.
 }

--- a/acbu_savings_vault/Cargo.toml
+++ b/acbu_savings_vault/Cargo.toml
@@ -14,3 +14,6 @@ shared = { path = "../shared" }
 [dev-dependencies]
 proptest = "1.11.0"
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -39,6 +39,7 @@ pub enum Error {
     NoPendingAdmin = 1019,
     AdminTimelockNotElapsed = 1020,
     NoPendingAdminToCancel = 1021,
+    InsufficientYieldReserve = 1022,
     Unknown = 1999,
 }
 
@@ -66,6 +67,7 @@ impl Display for Error {
             Self::NoPendingAdmin => "no pending admin",
             Self::AdminTimelockNotElapsed => "admin timelock has not elapsed",
             Self::NoPendingAdminToCancel => "no pending admin to cancel",
+            Self::InsufficientYieldReserve => "vault balance cannot cover principal + yield owed",
             Self::Unknown => "unknown savings vault error",
         };
         f.write_str(message)
@@ -406,6 +408,14 @@ impl SavingsVault {
         let token = soroban_sdk::token::Client::new(&env, &acbu);
         let vault_addr = env.current_contract_address();
 
+        // Yield is paid directly out of the vault's own ACBU balance — there is no
+        // external yield-generation mechanism funding it. Check the balance up front
+        // so an underfunded vault fails with a clear, specific error instead of the
+        // token contract's generic insufficient-balance panic.
+        if token.balance(&vault_addr) < payout_amount {
+            env.panic_with_error(Error::InsufficientYieldReserve);
+        }
+
         token.transfer(&vault_addr, &user, &amount);
         if yield_amount > 0 {
             token.transfer(&vault_addr, &user, &yield_amount);
@@ -686,7 +696,7 @@ impl SavingsVault {
         env.deployer().update_current_contract_wasm(wasm_hash);
         for v in current_version..new_version {
             match v {
-                0 => Self::migrate_v0_to_v1(env.clone()),
+                0 => shared::migrate_v0_to_v1(&env),
                 _ => {}
             }
         }
@@ -847,8 +857,5 @@ impl SavingsVault {
             .and_then(|v| v.checked_mul(elapsed_i128))
             .ok_or(Error::Overflow)?;
         numerator.checked_div(divisor).ok_or(Error::Overflow)
-    }
-    fn migrate_v0_to_v1(_env: Env) {
-        // No storage schema changes between v0 and v1.
     }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,3 +12,6 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ['testutils'] }
+
+[lints]
+workspace = true

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,8 +1,19 @@
 #![no_std]
 
-use soroban_sdk::{contracterror, contracttype, Address, String as SorobanString, Vec};
+use soroban_sdk::{contracterror, contracttype, Address, Env, String as SorobanString, Vec};
 
 pub mod reentrancy_guard;
+
+/// Shared no-op migration step for the v0 -> v1 storage schema transition.
+///
+/// Each contract's `upgrade` version-walk dispatches to this for the `v == 0`
+/// arm. Centralised here so the (previously identical) per-contract migration
+/// body isn't duplicated across contracts; a contract whose v0->v1 transition
+/// needs real schema changes should replace its dispatch arm with a local
+/// function instead of calling this one.
+pub fn migrate_v0_to_v1(_env: &Env) {
+    // No storage schema changes between v0 and v1.
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
# Fix: Address 3 audit findings (yield reserve check, workspace lint inheritance, duplicate migration code)

## Summary

Addresses three findings from the contract audit:

1. **LOW** — `acbu_savings_vault`: yield is paid directly from the contract's own ACBU balance with no external yield-generation mechanism; an underfunded vault failed withdrawals with an opaque token-transfer error.
2. **LOW** — 7 of 8 contract `Cargo.toml` files didn't inherit the workspace lint policy (`unused_imports = deny`, clippy warnings), so `acbu_multisig` was the only crate enforcing it.
3. **MEDIUM** — Every contract that supports versioned upgrades defined an identical `fn migrate_v0_to_v1(_env: Env) { /* no-op */ }`, duplicated across contracts instead of shared.

## Changes

### 1. Explicit insufficient-yield-reserve check (`acbu_savings_vault/src/lib.rs`)

- Added `Error::InsufficientYieldReserve` (code `1022`).
- In `withdraw`, before transferring principal + yield, the vault now checks its own ACBU balance against the total payout amount and panics with the new, specific error if the balance can't cover it.
- This doesn't add an external yield source (out of scope for a LOW finding) — it turns an underfunded withdrawal from a generic/opaque token-transfer failure into a clear, named contract error so callers and indexers can distinguish "vault needs topping up" from other failure modes.

### 2. Workspace lint inheritance (`*/Cargo.toml`)

- Added
  ```toml
  [lints]
  workspace = true
  ```
  to `acbu_minting`, `acbu_burning`, `acbu_oracle`, `acbu_reserve_tracker`, `acbu_savings_vault`, `acbu_lending_pool`, `acbu_escrow`, and `shared`.
- `acbu_multisig` already had this. Now every workspace member enforces `unused_imports = "deny"` and the shared clippy policy defined in the root `Cargo.toml`.

### 3. Shared `migrate_v0_to_v1` helper (`shared/src/lib.rs` + 6 contracts)

- Added `pub fn migrate_v0_to_v1(_env: &Env)` to the `shared` crate as the single source of truth for the no-op v0→v1 migration step.
- Removed the duplicated local `fn migrate_v0_to_v1` (or `Self::migrate_v0_to_v1` in `acbu_savings_vault`) from `acbu_minting`, `acbu_burning`, `acbu_oracle`, `acbu_reserve_tracker`, `acbu_lending_pool`, and `acbu_savings_vault`, and repointed each `upgrade` version-walk to call `shared::migrate_v0_to_v1(&env)`.
- `acbu_escrow` and `acbu_multisig` use a different migration mechanism (a standalone `migrate()` that bumps the stored version, with no per-version match/loop) and were left untouched — they never had the duplicated function.
- A contract whose future v0→v1 transition needs real schema changes should replace its dispatch arm with a local function instead of calling the shared no-op.

## Incidental fix

While touching `acbu_burning/src/lib.rs` for change #3, found that its `use shared::{...}` import list had been left empty by a bad merge-conflict resolution in `4a55042` (`Merge branch 'dev' into fix/326-burning-redeem-basket-precision-loss`) — the crate could not compile as-is (`ContractError`, `BurnEvent`, `CurrencyCode`, etc. were all unresolved). Restored the import list from the last commit before the merge, dropping `DECIMALS` since it's no longer referenced anywhere in the file (and would otherwise trip the newly-enforced `unused_imports = deny` lint from change #2).

## Files changed

- `acbu_savings_vault/src/lib.rs`
- `acbu_burning/src/lib.rs`
- `acbu_minting/src/lib.rs`
- `acbu_oracle/src/lib.rs`
- `acbu_reserve_tracker/src/lib.rs`
- `acbu_lending_pool/src/lib.rs`
- `shared/src/lib.rs`
- `acbu_minting/Cargo.toml`, `acbu_burning/Cargo.toml`, `acbu_oracle/Cargo.toml`, `acbu_reserve_tracker/Cargo.toml`, `acbu_savings_vault/Cargo.toml`, `acbu_lending_pool/Cargo.toml`, `acbu_escrow/Cargo.toml`, `shared/Cargo.toml`

## Test plan

- [ ] `cargo build --workspace` — confirm the restored `acbu_burning` imports compile and no crate trips the new `unused_imports`/clippy lints.
- [ ] `cargo test -p acbu_savings_vault` — cover the new `InsufficientYieldReserve` path (withdraw when vault balance < principal + yield owed) alongside existing withdraw tests.
- [ ] `cargo test --workspace` — confirm `upgrade`/migration behavior is unchanged for `acbu_minting`, `acbu_burning`, `acbu_oracle`, `acbu_reserve_tracker`, `acbu_lending_pool`, `acbu_savings_vault` after switching to `shared::migrate_v0_to_v1`.







closes #492
closes #493
closes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear error when the savings vault cannot cover a withdrawal’s principal and yield.
  * Centralized upgrade migration handling across contracts.
* **Bug Fixes**
  * Savings vault withdrawals now verify sufficient funds before processing payouts.
* **Maintenance**
  * Standardized lint configuration across workspace components.
  * Improved consistency of contract upgrade behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->