### PR TITLE
Add read-only getter functions for contract state variables

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -452,6 +452,88 @@ impl BurningContract {
             .get(&DATA_KEY.pending_admin_eligible_at)
     }
 
+    pub fn is_paused(env: Env) -> bool {
+        let phase: ContractPhase = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.phase)
+            .unwrap_or(ContractPhase::Active);
+        matches!(phase, ContractPhase::Paused)
+    }
+
+    pub fn get_phase(env: Env) -> ContractPhase {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.phase)
+            .unwrap_or(ContractPhase::Active)
+    }
+
+    pub fn get_fee_rate(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.fee_rate)
+            .unwrap_or(0)
+    }
+
+    pub fn get_fee_single_redeem(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.fee_single_redeem)
+            .unwrap_or(0)
+    }
+
+    pub fn get_acbu_token(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.acbu_token)
+            .unwrap()
+    }
+
+    pub fn get_oracle(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.oracle)
+            .unwrap()
+    }
+
+    pub fn get_reserve_tracker(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.reserve_tracker)
+            .unwrap()
+    }
+
+    pub fn get_withdrawal_processor(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.withdrawal_processor)
+            .unwrap()
+    }
+
+    pub fn get_vault(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.vault)
+            .unwrap()
+    }
+
+    pub fn get_min_burn_amount(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DATA_KEY.min_burn_amount)
+            .unwrap_or(MIN_BURN_AMOUNT)
+    }
+
+    pub fn get_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&SharedDataKey::Version)
+            .unwrap_or(0)
+    }
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DATA_KEY.admin)
+    }
 
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);


### PR DESCRIPTION
## Summary 

### Changes Made
Added 12 new read-only getter functions to match the minting contract's API:
| Getter |  Returns  |  Description |
| :------- | ------- |  -------  |
| is_paused()  |  bool  |  Whether contract is paused  |
| get_phase()  |  ContractPhase  |  Current contract phase (Active/Paused)  |
| get_fee_rate()  |  i128  |  Basket redeem fee rate (BPS)  |
| get_fee_single_redeem()  |  i128  |  Single currency redeem fee rate (BPS)  |
| get_acbu_token()  |  Address  |  ACBU token contract address  |
| get_oracle()  |  Address  |  Oracle contract address  |
| get_reserve_tracker()  |  Address  |  Reserve tracker contract address  |
| get_withdrawal_processor()  |  Address  |  Withdrawal processor address  |
| get_vault()  |  Address  |  Vault address  |
| get_min_burn_amount()  |  i128  |  Minimum burn amount  |
| get_version()	 |  u32	 |  Contract version  |
| is_initialized()  |  bool  |  Whether contract is initialized  |

The backend can now query all contract state without direct storage inspection.

Closes #483 