### PR TITLE
fix: get_rate_decimals ignores env parameter

### DIFF
--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -1437,14 +1437,24 @@ fn next_tx_nonce(env: &Env) -> u64 {
 // C-058 — minting to a contract address that has no token-receipt logic would
 // permanently strand funds.
 //
-// NOTE: soroban-sdk 21 does not expose an `is_account()` predicate on
-// `Address`; the distinction is enforced off-chain by the client SDK and by
-// Stellar's native authorization model.  This stub preserves the call sites so
-// the intent is visible and can be filled in when the SDK gains the API.
+// soroban-sdk 21 does not expose an `is_account()` predicate on `Address`, but
+// the strkey encoding returned by `Address::to_string()` reveals the address
+// kind: standard Stellar account (ed25519 public key) strkeys start with 'G',
+// while contract strkeys start with 'C'. Both encodings are 56 characters
+// long, so any address that doesn't decode to a 56-byte 'G...' string is
+// rejected.
 // ---------------------------------------------------------------------------
-fn assert_recipient_is_account(_address: &Address) {
-    // On-chain account-vs-contract check is not available in soroban-sdk 21.
-    // Enforcement is the responsibility of the calling client.
+fn assert_recipient_is_account(address: &Address) {
+    let env = address.env();
+    let strkey = address.to_string();
+    if strkey.len() != 56 {
+        env.panic_with_error(MintingError::InvalidRecipient);
+    }
+    let mut buf = [0u8; 56];
+    strkey.copy_into_slice(&mut buf);
+    if buf[0] != b'G' {
+        env.panic_with_error(MintingError::InvalidRecipient);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -75,6 +75,8 @@ impl Display for OracleError {
 
 pub const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
 const MIN_ORACLE_SOURCE_FEEDS: u32 = 3;
+/// Number of decimal places used for all rates reported by this oracle.
+const RATE_DECIMALS: u32 = 7;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -865,8 +867,8 @@ impl OracleContract {
     }
 
     /// Return the number of decimal places used for all rates (always 7).
-    pub fn get_rate_decimals(env: Env) -> u32 {
-        7
+    pub fn get_rate_decimals(_env: Env) -> u32 {
+        RATE_DECIMALS
     }
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION

- acbu_minting/src/lib.rs — assert_recipient_is_account now actually enforces the check via strkey decoding: Address::to_string() yields Stellar's strkey encoding, where account addresses start with 'G' and contract addresses with 'C' (both 56 chars). Any recipient that isn't a well-formed 56-char 'G...' account strkey now panics with MintingError::InvalidRecipient.
- acbu_oracle/src/lib.rs — added a RATE_DECIMALS: u32 = 7 constant and had get_rate_decimals return it, renaming the unused param to _env since rate decimals is a fixed protocol constant with nothing to look up.


closes #485
closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure recipient addresses use the expected account format before processing.
  * Invalid or non-account address formats are now rejected more reliably.

* **Improvements**
  * Standardized oracle rate precision to 7 decimal places.
  * Rate precision is now consistently reported across oracle interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->