### PR TITLE
fix(#507): add missing current_time declaration in redeem_single

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -142,7 +142,7 @@ impl BurningContract {
             .get(&DATA_KEY.reserve_tracker)
             .unwrap();
 
-
+        let current_time = env.ledger().timestamp();
         let (acbu_rate, oracle_timestamp): (i128, u64) = env.invoke_contract(
             &oracle_addr,
             &Symbol::new(&env, ORACLE_GET_ACBU_RATE_WITH_TS),

--- a/acbu_burning/tests/redeem_single.rs
+++ b/acbu_burning/tests/redeem_single.rs
@@ -4,7 +4,7 @@
 mod common;
 use common::{create_stoken, setup_test};
 use shared::{CurrencyCode, BASIS_POINTS, DECIMALS};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
 
 #[test]
 fn test_redeem_single_success() {
@@ -295,4 +295,43 @@ fn test_redeem_single_large_amount() {
 
     assert!(out > 0);
     assert_eq!(ctx.acbu_token.balance(&ctx.user), 0, "ctx.acbu_token.balance(&ctx.user) should equal 0");
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_redeem_single_stale_acbu_rate() {
+    let env = Env::default();
+    let ctx = setup_test(&env);
+
+    let currency = CurrencyCode::new(&env, "NGN");
+
+    // Advance ledger past staleness threshold (UPDATE_INTERVAL_SECONDS = 21,600)
+    env.ledger().with_mut(|l| l.timestamp = 100_000);
+
+    // ACBU rate timestamp is stale (0) → first oracle staleness check fails
+    ctx.oracle.set_acbu_rate(&DECIMALS, &0);
+
+    let recipient = Address::generate(&env);
+    ctx.burning
+        .redeem_single(&ctx.user, &recipient, &(100 * DECIMALS), &currency);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_redeem_single_stale_currency_rate() {
+    let env = Env::default();
+    let ctx = setup_test(&env);
+
+    let currency = CurrencyCode::new(&env, "NGN");
+
+    // Advance ledger past staleness threshold
+    env.ledger().with_mut(|l| l.timestamp = 100_000);
+
+    // ACBU rate is fresh (matches ledger) so first check passes
+    ctx.oracle.set_acbu_rate(&DECIMALS, &100_000);
+
+    // Currency rate timestamp is unset → defaults to 0 in mock → stale
+    let recipient = Address::generate(&env);
+    ctx.burning
+        .redeem_single(&ctx.user, &recipient, &(100 * DECIMALS), &currency);
 }


### PR DESCRIPTION
## Summary

Closes #507

Fixes the compile error in `acbu_burning::redeem_single` caused by `current_time` being referenced without being defined.

The fix initializes `current_time` from the current ledger timestamp before the existing oracle staleness checks, matching the pattern already used by `redeem_basket`.

## Changes

- Added `let current_time = env.ledger().timestamp();` inside `redeem_single` before the oracle staleness checks.
- Added regression coverage for:
  - stale ACBU oracle rate
  - stale currency oracle rate
- Updated the test import to include the required `Ledger` trait.

## Testing

Added two focused regression tests in `acbu_burning/tests/redeem_single.rs`:

- `test_redeem_single_stale_acbu_rate`
- `test_redeem_single_stale_currency_rate`

Both verify that stale oracle data is rejected with `OracleError` (`Error(Contract, #8)`).

## Verification Note

Full workspace `cargo check` / `cargo test` is currently blocked by a pre-existing issue on the `dev` branch in `shared/src/lib.rs`.

The `ContractError::Display` implementation references the following variants that are not present in the `ContractError` enum:

- `NoPendingAdmin`
- `AdminTimelockNotElapsed`
- `NoPendingAdminToCancel`

This issue is unrelated to #507 and was intentionally left unchanged to keep this PR scoped to `redeem_single`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oracle rate validation by using the current ledger time when checking rate freshness.
  * Added safeguards for stale ACBU and currency exchange rates during single-asset redemption.
  * Redemption requests now correctly reject outdated oracle data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->