### PR TITLE
fix(acbu_multisig): re-validate signers at execute time

### DIFF
--- a/acbu_multisig/src/lib.rs
+++ b/acbu_multisig/src/lib.rs
@@ -267,6 +267,9 @@ impl MultisigContract {
         if env.ledger().timestamp() > proposal.expires_at {
             env.panic_with_error(Error::Expired);
         }
+        for addr in proposal.approvals.iter() {
+            Self::assert_is_signer(&env, &addr, &config);
+        }
         if proposal.approvals.len() < config.threshold {
             env.panic_with_error(Error::ThresholdNotMet);
         }

--- a/acbu_multisig/tests/test.rs
+++ b/acbu_multisig/tests/test.rs
@@ -293,3 +293,27 @@ fn test_is_signer_false_for_outsider() {
     let outsider = Address::generate(&env);
     assert!(!client.is_signer(&outsider));
 }
+
+// ── Regression: signer removal after approval ───────────────────────────────
+
+/// Approvals from a signer who was later removed must not count toward the
+/// threshold at execution time.
+#[test]
+#[should_panic]
+fn test_execute_after_signer_removed_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (signers, client) = setup(&env, 3, 2);
+    let pid = client.propose(&signers[0], &SorobanString::from_str(&env, "pause"));
+    client.approve(&signers[1], &pid);
+
+    // Rotate signer set: remove signers[0], keep signers[1], add a new signer.
+    let mut new_signers = soroban_sdk::Vec::new(&env);
+    new_signers.push_back(signers[1].clone());
+    new_signers.push_back(signers[2].clone());
+    new_signers.push_back(Address::generate(&env));
+    client.update_config(&new_signers, &2);
+
+    // signers[0] approved but is no longer a signer — execute must panic.
+    client.execute(&signers[2], &pid);
+}


### PR DESCRIPTION
## Summary

Closes #522

Fixes stale multisig approvals being counted after the signer set changes.

Previously, `execute()` only compared `proposal.approvals.len()` against the current threshold. It did not verify that every approver was still part of the current signer set, allowing an approval from a removed signer to remain valid at execution time.

## Fix

Re-validates every address in `proposal.approvals` against the current signer configuration before checking the approval threshold.

If a signer was removed after approving but before execution, `execute()` now rejects the proposal with `Unauthorized` instead of counting the stale approval.

### Example

Before the fix:

1. Signers: Alice, Bob, Charlie — threshold `2`
2. Alice proposes and Bob approves
3. Signers rotate to Alice, Dave, Eve
4. Bob's stale approval still counts toward the threshold
5. `execute()` incorrectly proceeds

After the fix, Bob is no longer a valid signer at execution time, so the proposal is rejected.

## Changes

- `acbu_multisig/src/lib.rs`
  - Re-validates all proposal approvers against the current signer set before the threshold check.

- `acbu_multisig/tests/test.rs`
  - Added `test_execute_after_signer_removed_panics` regression coverage for signer rotation between approval and execution.

## Scope

- No changes to `propose()`, `approve()`, or `update_config()`
- No changes to other contracts or crates
- No frontend changes
- No unrelated refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened multisig proposal execution checks by ensuring all approvers remain authorized signers.
  * Approvals from signers removed before execution no longer count toward the approval threshold.

* **Tests**
  * Added regression coverage for signer removal after proposal approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->