### PR TITLE
fix(acbu_minting): remove tautological check_is_admin guard from admi…

### DIFF
--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -974,10 +974,6 @@ impl MintingContract {
         let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
         admin.require_auth();
 
-        if !Self::check_is_admin(&env, &admin) {
-            env.panic_with_error(MintingError::UnauthorizedOperator);
-        }
-
         // C-058: reject contract-type recipients to prevent stranded token transfers.
         Self::assert_recipient_is_account(&recipient);
         if amount <= 0 {


### PR DESCRIPTION
## Summary

Closes #527

Removes the redundant `check_is_admin()` guard from `admin_drip_fiat()`.

The function already loads the configured admin from storage and calls `admin.require_auth()`. The additional `check_is_admin(&env, &admin)` call re-read the same admin value from storage and compared it against itself, making the check tautological.

## Root Cause

The previous flow was effectively:

```text
Load admin from storage
        ↓
admin.require_auth()          ← actual authorization boundary
        ↓
Re-read admin from storage
        ↓
Compare stored admin == admin ← always true

```