### PR TITLE
fix(reserve_tracker): add oracle cross-validation to update_reserve

### DIFF
--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{
 };
 
 use shared::{
-    CurrencyCode, DataKey as SharedDataKey, ReserveData, BASIS_POINTS, CONTRACT_VERSION,
-    ORACLE_GET_ACBU_RATE, TOKEN_GET_TOTAL_SUPPLY,
+    CurrencyCode, DataKey as SharedDataKey, ReserveData, BASIS_POINTS, CONTRACT_VERSION, DECIMALS,
+    ORACLE_GET_ACBU_RATE, ORACLE_GET_RATE_WITH_TS, TOKEN_GET_TOTAL_SUPPLY,
 };
 
 #[contracterror]
@@ -21,6 +21,8 @@ pub enum ReserveTrackerError {
     AdminTimelockNotElapsed = 8005,
     NoPendingAdminToCancel = 8006,
     Unauthorized = 8007,
+    NonPositiveAmount = 8008,
+    InconsistentReserve = 8009,
     Unknown = 8999,
 }
 
@@ -34,6 +36,8 @@ impl Display for ReserveTrackerError {
             Self::AdminTimelockNotElapsed => "admin timelock has not elapsed",
             Self::NoPendingAdminToCancel => "no pending admin to cancel",
             Self::Unauthorized => "unauthorized",
+            Self::NonPositiveAmount => "amount and value_usd must be positive",
+            Self::InconsistentReserve => "value_usd inconsistent with oracle rate",
             Self::Unknown => "unknown reserve tracker error",
         };
         f.write_str(message)
@@ -157,7 +161,11 @@ impl ReserveTrackerContract {
         Self::is_reserve_sufficient(env, total_acbu_supply)
     }
 
-    /// Update reserve amount for a currency (admin or authorized address)
+    /// Update reserve amount for a currency (admin only).
+    ///
+    /// Cross-validates the caller-supplied `amount` and `value_usd` against the
+    /// oracle's live exchange rate for `currency`.  This prevents a compromised
+    /// admin key from inflating reserves to unlock arbitrary minting.
     pub fn update_reserve(
         env: Env,
         updater: Address,
@@ -165,16 +173,35 @@ impl ReserveTrackerContract {
         amount: i128,
         value_usd: i128,
     ) {
-        // Authorize updater
         updater.require_auth();
         let admin = Self::get_admin(env.clone());
         if updater != admin {
             env.panic_with_error(ReserveTrackerError::Unauthorized);
         }
 
+        if amount <= 0 || value_usd <= 0 {
+            env.panic_with_error(ReserveTrackerError::NonPositiveAmount);
+        }
+
+        let oracle_addr: Address = env.storage().instance().get(&DATA_KEY.oracle).unwrap();
+        let (rate, _rate_timestamp): (i128, u64) = env.invoke_contract(
+            &oracle_addr,
+            &Symbol::new(&env, ORACLE_GET_RATE_WITH_TS),
+            vec![&env, currency.clone().into_val(&env)],
+        );
+
+        let expected_value_usd = amount
+            .checked_mul(rate)
+            .and_then(|v| v.checked_div(DECIMALS))
+            .expect("Overflow in reserve value calculation");
+
+        let diff = value_usd.abs_diff(expected_value_usd);
+        if diff > 1 {
+            env.panic_with_error(ReserveTrackerError::InconsistentReserve);
+        }
+
         let current_time = env.ledger().timestamp();
 
-        // Update reserves map
         let mut reserves: Map<CurrencyCode, ReserveData> = env
             .storage()
             .instance()

--- a/acbu_reserve_tracker/tests/test.rs
+++ b/acbu_reserve_tracker/tests/test.rs
@@ -10,7 +10,8 @@ use soroban_sdk::{
 // ── Mock contracts in isolated modules to prevent symbol-name collisions ──────
 
 mod mock_oracle {
-    use soroban_sdk::{contract, contractimpl, Env};
+    use shared::CurrencyCode;
+    use soroban_sdk::{contract, contractimpl, symbol_short, Env, Map};
 
     #[contract]
     pub struct MockOracle;
@@ -19,6 +20,28 @@ mod mock_oracle {
     impl MockOracle {
         pub fn get_acbu_usd_rate(_env: Env) -> i128 {
             100_000_000 // 1 USD (8 decimals)
+        }
+
+        pub fn get_rate_with_timestamp(env: Env, currency: CurrencyCode) -> (i128, u64) {
+            let rates: Map<CurrencyCode, i128> = env
+                .storage()
+                .instance()
+                .get(&symbol_short!("rates"))
+                .unwrap_or(Map::new(&env));
+            let rate = rates.get(currency).unwrap_or(0);
+            (rate, env.ledger().timestamp())
+        }
+
+        pub fn set_rate(env: Env, currency: CurrencyCode, rate: i128) {
+            let mut rates: Map<CurrencyCode, i128> = env
+                .storage()
+                .instance()
+                .get(&symbol_short!("rates"))
+                .unwrap_or(Map::new(&env));
+            rates.set(currency, rate);
+            env.storage()
+                .instance()
+                .set(&symbol_short!("rates"), &rates);
         }
     }
 }
@@ -52,7 +75,7 @@ mod mock_token_zero {
     }
 }
 
-use mock_oracle::MockOracle;
+use mock_oracle::{MockOracle, MockOracleClient};
 use mock_token::MockToken;
 use mock_token_zero::MockTokenZero;
 
@@ -66,6 +89,7 @@ fn verify_reserves_uses_passed_supply_not_contract_balance() {
 
     let admin = Address::generate(&env);
     let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
     let min_ratio_bps = 10_000i128; // 100%
 
     let contract_id = env.register_contract(None, ReserveTrackerContract);
@@ -75,7 +99,9 @@ fn verify_reserves_uses_passed_supply_not_contract_balance() {
     client.initialize(&admin, &oracle, &acbu_token, &min_ratio_bps);
 
     let ngn = CurrencyCode::new(&env, "NGN");
-    client.update_reserve(&admin, &ngn, &1_000_000_000, &100_000_000); // 10 USD @ 7 decimals
+    // amount=1_000_000_000, value_usd=100_000_000 → rate = 1_000_000
+    oracle_client.set_rate(&ngn, &1_000_000);
+    client.update_reserve(&admin, &ngn, &1_000_000_000, &100_000_000);
 
     // 10 USD reserves vs 10 ACBU supply (10 * 10^7) at 100% min ratio → sufficient
     assert!(client.verify_reserves_manual(&(10 * 10_000_000)));
@@ -92,6 +118,7 @@ fn test_update_and_get_all_reserves_and_timestamp() {
 
     let admin = Address::generate(&env);
     let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
 
     let contract_id = env.register_contract(None, ReserveTrackerContract);
     let client = ReserveTrackerContractClient::new(&env, &contract_id);
@@ -100,6 +127,8 @@ fn test_update_and_get_all_reserves_and_timestamp() {
     client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
 
     let ngn = CurrencyCode::new(&env, "NGN");
+    // amount=500, value_usd=5*DECIMALS → rate = 1_000_000_000_000
+    oracle_client.set_rate(&ngn, &1_000_000_000_000);
     client.update_reserve(&admin, &ngn, &500, &(5 * DECIMALS));
 
     let reserves: soroban_sdk::Map<CurrencyCode, ReserveData> = client.get_all_reserves();
@@ -138,6 +167,7 @@ fn test_is_reserve_sufficient_multiple_currencies_and_verify_from_token() {
 
     let admin = Address::generate(&env);
     let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
     let token = env.register_contract(None, MockToken);
 
     let contract_id = env.register_contract(None, ReserveTrackerContract);
@@ -147,6 +177,11 @@ fn test_is_reserve_sufficient_multiple_currencies_and_verify_from_token() {
 
     let ngn = CurrencyCode::new(&env, "NGN");
     let kes = CurrencyCode::new(&env, "KES");
+
+    // amount=1000, value_usd=5*DECIMALS → rate = 500_000_000_000
+    oracle_client.set_rate(&ngn, &500_000_000_000);
+    // amount=2000, value_usd=5*DECIMALS → rate = 250_000_000_000
+    oracle_client.set_rate(&kes, &250_000_000_000);
 
     // 5 USD each -> total 10 USD
     client.update_reserve(&admin, &ngn, &1_000, &(5 * DECIMALS));
@@ -191,6 +226,7 @@ fn test_reset_reserves_by_admin_clears_all_entries() {
 
     let admin = Address::generate(&env);
     let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
 
     let contract_id = env.register_contract(None, ReserveTrackerContract);
     let client = ReserveTrackerContractClient::new(&env, &contract_id);
@@ -200,6 +236,8 @@ fn test_reset_reserves_by_admin_clears_all_entries() {
 
     let ngn = CurrencyCode::new(&env, "NGN");
     let kes = CurrencyCode::new(&env, "KES");
+    oracle_client.set_rate(&ngn, &500_000_000_000);
+    oracle_client.set_rate(&kes, &250_000_000_000);
     client.update_reserve(&admin, &ngn, &1_000, &(5 * DECIMALS));
     client.update_reserve(&admin, &kes, &2_000, &(5 * DECIMALS));
 
@@ -222,6 +260,7 @@ fn test_reset_reserves_without_admin_auth_fails() {
     let admin = Address::generate(&env);
     let attacker = Address::generate(&env);
     let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
 
     let contract_id = env.register_contract(None, ReserveTrackerContract);
     let client = ReserveTrackerContractClient::new(&env, &contract_id);
@@ -232,6 +271,7 @@ fn test_reset_reserves_without_admin_auth_fails() {
     client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
 
     let ngn = CurrencyCode::new(&env, "NGN");
+    oracle_client.set_rate(&ngn, &500_000_000_000);
     client.update_reserve(&admin, &ngn, &1_000, &(5 * DECIMALS));
 
     // Provide only the attacker's auth — reset_reserves must reject it.
@@ -326,5 +366,164 @@ fn test_update_reserve_without_admin_auth_fails() {
     assert!(
         result.is_err(),
         "update_reserve must reject callers that are not the admin"
+    );
+}
+
+// ── Oracle cross-validation tests ─────────────────────────────────────────────
+
+#[test]
+fn test_update_reserve_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    oracle_client.set_rate(&ngn, &DECIMALS);
+
+    let result = client.try_update_reserve(&admin, &ngn, &0, &DECIMALS);
+    assert!(result.is_err(), "update_reserve must reject zero amount");
+}
+
+#[test]
+fn test_update_reserve_rejects_negative_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    oracle_client.set_rate(&ngn, &DECIMALS);
+
+    let result = client.try_update_reserve(&admin, &ngn, &-1, &DECIMALS);
+    assert!(result.is_err(), "update_reserve must reject negative amount");
+}
+
+#[test]
+fn test_update_reserve_rejects_inconsistent_value_usd() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // rate = DECIMALS → expected_value_usd = amount (1 NGN = 1 USD)
+    oracle_client.set_rate(&ngn, &DECIMALS);
+
+    // amount=1000, rate=DECIMALS → expected value_usd = 1000
+    // Pass 2000 instead → must fail
+    let result = client.try_update_reserve(&admin, &ngn, &1000, &2000);
+    assert!(
+        result.is_err(),
+        "update_reserve must reject value_usd inconsistent with oracle rate"
+    );
+}
+
+#[test]
+fn test_update_reserve_accepts_consistent_value_usd() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // rate = DECIMALS → 1 NGN = 1 USD
+    oracle_client.set_rate(&ngn, &DECIMALS);
+
+    // amount=1000, rate=DECIMALS → expected value_usd = 1000
+    client.update_reserve(&admin, &ngn, &1000, &1000);
+
+    let reserves = client.get_all_reserves();
+    assert_eq!(reserves.len(), 1, "one reserve should be stored");
+}
+
+#[test]
+fn test_update_reserve_accepts_rounding_tolerance_of_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // rate = 3 → expected_value_usd = amount * 3 / DECIMALS = 3000 / 10_000_000 = 0
+    // value_usd = 1 → diff = 1 → within tolerance
+    oracle_client.set_rate(&ngn, &3);
+    client.update_reserve(&admin, &ngn, &1000, &1);
+
+    let reserves = client.get_all_reserves();
+    assert_eq!(reserves.len(), 1, "rounding tolerance of 1 must be accepted");
+}
+
+#[test]
+fn test_update_reserve_rejects_inflated_value_usd() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    let acbu_token = Address::generate(&env);
+    client.initialize(&admin, &oracle, &acbu_token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // rate = DECIMALS → expected_value_usd = amount
+    oracle_client.set_rate(&ngn, &DECIMALS);
+
+    // amount=1000 → expected value_usd = 1000
+    // Pass 1002 → diff = 2 > tolerance → must fail
+    let result = client.try_update_reserve(&admin, &ngn, &1000, &1002);
+    assert!(
+        result.is_err(),
+        "update_reserve must reject value_usd inflated beyond rounding tolerance"
     );
 }


### PR DESCRIPTION
Closes #516 

- Reject non-positive amount (ZeroAmount error 8008)
- Fetch oracle rate via get_rate_with_timestamp for consistency
- Compute expected_value_usd = amount * rate / DECIMALS
- Reject if abs_diff(value_usd, expected_value_usd) > 1 (InconsistentReserve 8009)
- Mock oracle updated with set_rate/get_rate_with_timestamp for testing
- All existing tests updated to set oracle rates before update_reserve calls
- New tests: zero amount, negative amount, inconsistent value_usd, rounding tolerance, inflated value_usd