### PR TITLE
fix(reserve_tracker): cache verify_reserves result during cooldown

### DIFF
--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -52,6 +52,7 @@ pub struct DataKey {
     pub pending_admin: Symbol,
     pub pending_admin_eligible_at: Symbol,
     pub last_verify_call: Symbol,
+    pub last_verify_result: Symbol,
 }
 
 const DATA_KEY: DataKey = DataKey {
@@ -64,6 +65,7 @@ const DATA_KEY: DataKey = DataKey {
     pending_admin: symbol_short!("PEND_ADM"),
     pending_admin_eligible_at: symbol_short!("PEND_ETA"),
     last_verify_call: symbol_short!("LAST_VFY"),
+    last_verify_result: symbol_short!("LAST_RES"),
 };
 
 /// Admin rotation timelock: the pending admin must wait this long before
@@ -137,7 +139,12 @@ impl ReserveTrackerContract {
         let last_call: Option<u64> = env.storage().instance().get(&DATA_KEY.last_verify_call);
         if let Some(last) = last_call {
             if now.saturating_sub(last) < VERIFY_RESERVES_COOLDOWN_SECONDS {
-                return false;
+                let cached: bool = env
+                    .storage()
+                    .instance()
+                    .get(&DATA_KEY.last_verify_result)
+                    .unwrap_or(true);
+                return cached;
             }
         }
 
@@ -147,7 +154,11 @@ impl ReserveTrackerContract {
         if total_acbu_supply == 0 {
             env.panic_with_error(ReserveTrackerError::ZeroSupply);
         }
-        Self::is_reserve_sufficient(env, total_acbu_supply)
+        let result = Self::is_reserve_sufficient(env.clone(), total_acbu_supply);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.last_verify_result, &result);
+        result
     }
 
     /// Like [`Self::verify_reserves`] but uses the caller-supplied

--- a/acbu_reserve_tracker/tests/test.rs
+++ b/acbu_reserve_tracker/tests/test.rs
@@ -328,3 +328,108 @@ fn test_update_reserve_without_admin_auth_fails() {
         "update_reserve must reject callers that are not the admin"
     );
 }
+
+#[test]
+fn test_verify_reserves_caches_result_during_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let token = env.register_contract(None, MockToken);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &oracle, &token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // 10 USD reserve
+    client.update_reserve(&admin, &ngn, &1_000_000_000, &100_000_000);
+
+    // First call at t=1: token returns 10*DECIMALS, reserves=10 USD → sufficient (true)
+    assert!(client.verify_reserves());
+
+    // Call again at t=10 (within 60s cooldown): must return cached result, not false
+    env.ledger().with_mut(|l| l.timestamp = 10);
+    assert!(
+        client.verify_reserves(),
+        "verify_reserves must return cached true during cooldown, not false"
+    );
+
+    // After cooldown expires at t=61, re-checks fresh
+    env.ledger().with_mut(|l| l.timestamp = 61);
+    assert!(client.verify_reserves());
+}
+
+#[test]
+fn test_verify_reserves_caches_false_during_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let token = env.register_contract(None, MockToken);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &oracle, &token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // Tiny reserve (0.1 USD) vs 10 ACBU supply → insufficient
+    client.update_reserve(&admin, &ngn, &1, &10_000_000);
+
+    // First call: insufficient (false)
+    assert!(!client.verify_reserves());
+
+    // Within cooldown: returns cached false (not a stale true)
+    env.ledger().with_mut(|l| l.timestamp = 30);
+    assert!(
+        !client.verify_reserves(),
+        "verify_reserves must return cached false during cooldown"
+    );
+}
+
+#[test]
+fn test_verify_reserves_refreshes_after_cooldown_expires() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let admin = Address::generate(&env);
+    let oracle = env.register_contract(None, MockOracle);
+    let token = env.register_contract(None, MockToken);
+
+    let contract_id = env.register_contract(None, ReserveTrackerContract);
+    let client = ReserveTrackerContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &oracle, &token, &10_000i128);
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    // Tiny reserve → insufficient
+    client.update_reserve(&admin, &ngn, &1, &10_000_000);
+
+    // First call: false
+    assert!(!client.verify_reserves());
+
+    // Add real reserves
+    env.ledger().with_mut(|l| l.timestamp = 2);
+    client.update_reserve(&admin, &ngn, &1_000_000_000, &100_000_000);
+
+    // Still within cooldown of first call → returns cached false
+    env.ledger().with_mut(|l| l.timestamp = 30);
+    assert!(
+        !client.verify_reserves(),
+        "must still return cached false within cooldown of first call"
+    );
+
+    // After cooldown (t=61 > 1+60): fresh check sees new reserves → true
+    env.ledger().with_mut(|l| l.timestamp = 61);
+    assert!(
+        client.verify_reserves(),
+        "must re-evaluate after cooldown expires and return true"
+    );
+}


### PR DESCRIPTION
Closes #518 

Previously verify_reserves returned false during the 60-second cooldown, indistinguishable from genuine insolvency. Now the last verification result is cached alongside the timestamp; subsequent calls within the cooldown return the cached value instead. This prevents external systems from false-positive detecting insolvency when reserves are actually sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reserve verification now consistently returns the previously determined result during the cooldown period, including both sufficient and insufficient reserve states.
  * Verification results are refreshed automatically after the cooldown expires, ensuring subsequent checks reflect updated reserve conditions.
  * Improved consistency for repeated reserve checks and prevented temporary calls from incorrectly reporting insufficient reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->