### PR TITLE
fix: address audit findings #486, #495, #533

### DIFF
--- a/acbu_escrow/src/lib.rs
+++ b/acbu_escrow/src/lib.rs
@@ -143,6 +143,17 @@ impl Escrow {
             .ok_or(EscrowError::UninitializedAcBuToken)
     }
 
+    fn check_paused(env: &Env) {
+        let phase: ContractPhase = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.phase)
+            .unwrap_or(ContractPhase::Uninitialized);
+        if phase == ContractPhase::Paused {
+            env.panic_with_error(EscrowError::Paused);
+        }
+    }
+
     /// Initialize the escrow contract
     pub fn initialize(env: Env, admin: Address, acbu_token: Address) {
         if env.storage().instance().has(&DATA_KEY.admin) {
@@ -187,14 +198,8 @@ impl Escrow {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
 
-        let phase: ContractPhase = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.phase)
-            .unwrap_or(ContractPhase::Uninitialized);
-        if phase == ContractPhase::Paused {
-            env.panic_with_error(EscrowError::Paused);
-        }
+        Self::check_paused(&env);
+
         if amount < MIN_ESCROW_AMOUNT {
             env.panic_with_error(EscrowError::InvalidAmount);
         }
@@ -247,14 +252,8 @@ impl Escrow {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
 
-        let phase: ContractPhase = env
-            .storage()
-            .instance()
-            .get(&DATA_KEY.phase)
-            .unwrap_or(ContractPhase::Uninitialized);
-        if phase == ContractPhase::Paused {
-            env.panic_with_error(EscrowError::Paused);
-        }
+        Self::check_paused(&env);
+
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
         if payer == admin {
             admin.require_auth();
@@ -297,7 +296,6 @@ impl Escrow {
         reentrancy_guard::acquire_guard(&env);
 
         let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
-        admin.require_auth();
 
         let key = EscrowId(payer.clone(), escrow_id);
         let (stored_payer, _payee, amount, expiry): (Address, Address, i128, u64) = env
@@ -310,7 +308,7 @@ impl Escrow {
             env.panic_with_error(EscrowError::PayerMismatch);
         }
 
-        let admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
+        // After expiry the payer may self-refund; before expiry only admin can force a refund.
         if env.ledger().timestamp() > expiry {
             payer.require_auth();
         } else {

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -210,7 +210,7 @@ impl LendingPool {
         reentrancy_guard::acquire_guard(&env);
 
         lender.require_auth();
-        Self::check_not_paused(&env);
+        Self::check_paused(&env);
 
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
@@ -258,7 +258,7 @@ impl LendingPool {
         reentrancy_guard::acquire_guard(&env);
 
         lender.require_auth();
-        Self::check_not_paused(&env);
+        Self::check_paused(&env);
 
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
@@ -324,7 +324,7 @@ impl LendingPool {
         reentrancy_guard::acquire_guard(&env);
 
         borrower.require_auth();
-        Self::check_not_paused(&env);
+        Self::check_paused(&env);
 
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
@@ -475,7 +475,7 @@ impl LendingPool {
         reentrancy_guard::acquire_guard(&env);
 
         borrower.require_auth();
-        Self::check_not_paused(&env);
+        Self::check_paused(&env);
 
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
@@ -840,7 +840,7 @@ impl LendingPool {
         admin.require_auth();
     }
 
-    fn check_not_paused(env: &Env) {
+    fn check_paused(env: &Env) {
         let phase: ContractPhase = env
             .storage()
             .instance()

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -510,6 +510,9 @@ impl MintingContract {
         env.events()
             .publish((symbol_short!("mint"), recipient), mint_event);
 
+        // Seal the proof so it cannot be replayed (fixes the check_proof_unused guard above).
+        mark_proof_used(&env, &proof_id);
+
         // Release re-entrancy guard
         reentrancy_guard::release_guard(&env);
 

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -199,13 +199,15 @@ impl SavingsVault {
             .ok_or(Error::NoYieldRate)
     }
 
-    fn is_paused(env: &Env) -> bool {
+    fn check_paused(env: &Env) {
         let phase: ContractPhase = env
             .storage()
             .instance()
             .get(&DATA_KEY.phase)
             .unwrap_or(ContractPhase::Uninitialized);
-        phase == ContractPhase::Paused
+        if phase == ContractPhase::Paused {
+            env.panic_with_error(Error::Paused);
+        }
     }
 
     fn extend_instance_ttl(env: &Env) {
@@ -268,9 +270,8 @@ impl SavingsVault {
 
         user.require_auth();
 
-        if Self::is_paused(&env) {
-            env.panic_with_error(Error::Paused);
-        }
+        Self::check_paused(&env);
+
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
         }
@@ -355,9 +356,8 @@ impl SavingsVault {
 
         user.require_auth();
 
-        if Self::is_paused(&env) {
-            env.panic_with_error(Error::Paused);
-        }
+        Self::check_paused(&env);
+
         if amount <= 0 {
             env.panic_with_error(Error::InvalidAmount);
         }


### PR DESCRIPTION
#533 [CRITICAL] acbu_minting: add mark_proof_used in mint_from_basket
- mint_from_basket called check_proof_unused on entry but never sealed the proof, making replay protection permanently bypassable
- Add mark_proof_used(&env, &proof_id) before reentrancy guard release, matching the identical pattern already present in mint_from_demo_fiat

#486 [LOW] acbu_escrow: remove duplicate admin load in refund
- refund loaded admin from storage twice; second binding shadowed first
- Remove the first unconditional require_auth() and second redundant load; defer auth to after the expiry check (single load used throughout)

#495 [MEDIUM] standardize pause guard naming to check_paused
- lending_pool: rename check_not_paused -> check_paused (4 call sites)
- savings_vault: replace is_paused bool helper + manual if-panic pattern with a direct check_paused helper matching minting/burning convention
- escrow: replace two inline 6-line phase-check blocks with Self::check_paused calls; add private check_paused helper



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escrow payers can now request refunds directly after the escrow has expired.
* **Bug Fixes**
  * Prevented basket mint proofs from being reused.
  * Standardized paused-state enforcement across escrow, lending, and savings operations, ensuring affected actions are consistently blocked while paused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

cloese #486 
closes #495 
closes #533 
closes #486 