### PR TITLE
fix(sc-025): make emergency threshold configurable, require N-of-M co…

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -1,13 +1,14 @@
 #![no_std]
 use core::fmt::{self, Display};
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contractmeta, contracttype, symbol_short, Address,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address,
     BytesN, Env, Map, Symbol, Vec,
 };
 
 use shared::{
-    calculate_deviation, median, CurrencyCode, DataKey as SharedDataKey, OutlierDetectionEvent,
-    RateData, RateUpdateEvent, BASIS_POINTS, CONTRACT_VERSION, DECIMALS, EMERGENCY_THRESHOLD_BPS,
+    calculate_deviation, median, CurrencyCode, DataKey as SharedDataKey, EmergencyBypassEvent,
+    EmergencyConfig, EmergencyVote, EmergencyVoteCastEvent, OutlierDetectionEvent, RateData,
+    RateUpdateEvent, BASIS_POINTS, CONTRACT_VERSION, EMERGENCY_THRESHOLD_BPS,
     MAX_VALIDATORS, OUTLIER_THRESHOLD_BPS, STALE_RATE_MAX_LEDGERS, UPDATE_INTERVAL_SECONDS,
 };
 
@@ -39,6 +40,9 @@ pub enum OracleError {
     TimestampRollback = 7022,
     RateNotInitialized = 7023,
     CurrencyNotRegistered = 7024,
+    /// Emergency vote cast but consensus not yet reached — caller must wait for
+    /// more validators to submit corroborating emergency rates.
+    InsufficientEmergencyVotes = 7025,
     Unknown = 7999,
 }
 
@@ -69,6 +73,7 @@ impl Display for OracleError {
             Self::TimestampRollback => "timestamp rollback",
             Self::RateNotInitialized => "rate not initialized - no submissions yet",
             Self::CurrencyNotRegistered => "currency not registered",
+            Self::InsufficientEmergencyVotes => "emergency vote cast - waiting for N-of-M validator consensus",
             Self::Unknown => "unknown oracle error",
         };
         f.write_str(message)
@@ -109,6 +114,10 @@ pub struct DataKey {
     pub pending_validator: Symbol,
     pub pending_validator_is_add: Symbol,
     pub pending_validator_eligible_at: Symbol,
+    /// Map<CurrencyCode, EmergencyConfig> — per-pair emergency threshold config.
+    pub emergency_thresholds: Symbol,
+    /// Map<CurrencyCode, Vec<EmergencyVote>> — pending emergency votes per pair.
+    pub emergency_votes: Symbol,
 }
 
 const DATA_KEY: DataKey = DataKey {
@@ -131,32 +140,39 @@ const DATA_KEY: DataKey = DataKey {
     pending_validator: symbol_short!("PEND_VAL"),
     pending_validator_is_add: symbol_short!("PEND_VADD"),
     pending_validator_eligible_at: symbol_short!("PEND_VETA"),
+    emergency_thresholds: symbol_short!("EMRG_THR"),
+    emergency_votes: symbol_short!("EMRG_VOT"),
 };
 
 const VERSION: u32 = 9;
 
-#[contractevent]
+/// Number of seconds after which pending emergency votes expire and are cleared.
+/// Set to 1 hour — long enough for validators to respond but short enough to
+/// prevent stale votes from trickling into a later genuine crisis.
+const EMERGENCY_VOTE_TTL_SECONDS: u64 = 3_600;
+
+#[contracttype]
 pub struct AdminTransferInitiatedEvent {
     pub current_admin: Address,
     pub pending_admin: Address,
     pub eligible_at: u64,
 }
 
-#[contractevent]
+#[contracttype]
 pub struct AdminTransferCompletedEvent {
     pub old_admin: Address,
     pub new_admin: Address,
     pub timestamp: u64,
 }
 
-#[contractevent]
+#[contracttype]
 pub struct AdminTransferCancelledEvent {
     pub admin: Address,
     pub cancelled_pending: Address,
     pub timestamp: u64,
 }
 
-#[contractevent]
+#[contracttype]
 pub struct StaleRateEvent {
     pub currency: CurrencyCode,
     pub stored_ledger: u32,
@@ -373,9 +389,13 @@ impl OracleContract {
     /// median is taken and feeds deviating beyond [`OUTLIER_THRESHOLD_BPS`] are
     /// discarded as outliers (emitting `OutlierDetectionEvent`). Updates are
     /// rate-limited to the configured update interval unless the new rate deviates
-    /// beyond [`EMERGENCY_THRESHOLD_BPS`]. Rejects timestamps older than the stored
-    /// rate. The `_timestamp` parameter is ignored; the ledger timestamp is used.
-    /// Emits `RateUpdateEvent`.
+    /// beyond the per-currency emergency threshold **and** at least `min_signatures`
+    /// validators have all independently cast emergency votes via
+    /// [`Self::cast_emergency_vote`] (N-of-M consensus). A single validator can no
+    /// longer unilaterally bypass the time-lock. Rejects timestamps older than the
+    /// stored rate. The `_timestamp` parameter is ignored; the ledger timestamp is
+    /// used. Emits `RateUpdateEvent` and, when an emergency bypass fires, also emits
+    /// `EmergencyBypassEvent`.
     pub fn update_rate(
         env: Env,
         validator: Address,
@@ -417,25 +437,58 @@ impl OracleContract {
                 env.panic_with_error(OracleError::TimestampRollback);
             }
         }
-        let mut allow_update = false;
-        if let Some(existing_rate) = existing_rate.clone() {
-            let deviation = calculate_deviation(rate, existing_rate.rate_usd);
-            if deviation > EMERGENCY_THRESHOLD_BPS {
-                allow_update = true;
-            }
-        }
-
-        if let Some(existing_rate) = existing_rate {
-            if !allow_update && current_time < existing_rate.timestamp + update_interval {
-                env.panic_with_error(OracleError::UpdateIntervalNotMet);
-            }
-        }
 
         let min_sigs: u32 = env
             .storage()
             .instance()
             .get(&DATA_KEY.min_signatures)
             .unwrap();
+
+        // ── Emergency bypass logic (SC-025) ──────────────────────────────────
+        //
+        // A single validator can no longer unilaterally bypass the time-lock.
+        // The two-step flow is:
+        //
+        //  1. Each validator that believes an emergency exists calls
+        //     `cast_emergency_vote(validator, currency, rate)` — this always
+        //     succeeds and persists the vote (it never panics, so storage is
+        //     never rolled back).
+        //
+        //  2. Once `min_signatures` qualifying votes exist, any validator may
+        //     call `update_rate` with the emergency rate. This function checks
+        //     whether the consensus has been reached: if yes it clears the votes
+        //     and grants the bypass (emitting `EmergencyBypassEvent`); if not it
+        //     falls through to the regular interval check and fails with
+        //     `UpdateIntervalNotMet`.
+        //
+        // The separation is critical: because Soroban rolls back all storage
+        // writes inside a panicking call, votes must be persisted via a
+        // dedicated non-panicking function rather than inside `update_rate`.
+        // ─────────────────────────────────────────────────────────────────────
+
+        let mut allow_update = false;
+        if let Some(ref existing) = existing_rate {
+            let emergency_threshold = Self::get_emergency_threshold_bps(&env, &currency);
+            let deviation = calculate_deviation(rate, existing.rate_usd);
+            if deviation > emergency_threshold {
+                // Check whether N-of-M consensus already exists (votes were
+                // pre-registered via cast_emergency_vote).
+                allow_update = Self::check_and_consume_emergency_votes(
+                    &env,
+                    &currency,
+                    current_time,
+                    min_sigs,
+                    rate,
+                );
+            }
+        }
+
+        if let Some(ref existing) = existing_rate {
+            if !allow_update && current_time < existing.timestamp + update_interval {
+                env.panic_with_error(OracleError::UpdateIntervalNotMet);
+            }
+        }
+
         let required = min_sigs.max(MIN_ORACLE_SOURCE_FEEDS);
         // The 0/1-source path below intentionally bypasses median/outlier
         // aggregation, so the multi-source quorum floor only applies once
@@ -481,6 +534,20 @@ impl OracleContract {
             }
         };
 
+        if allow_update {
+            // Emit bypass event now that we know the final median rate.
+            let vote_count = min_sigs; // consensus already confirmed above
+            env.events().publish(
+                (symbol_short!("emrg_byp"),),
+                EmergencyBypassEvent {
+                    currency: currency.clone(),
+                    new_rate: median_rate,
+                    vote_count,
+                    timestamp: current_time,
+                },
+            );
+        }
+
         let rate_data = RateData {
             currency: currency.clone(),
             rate_usd: median_rate,
@@ -508,6 +575,122 @@ impl OracleContract {
             validator: validator.clone(),
         };
         env.events().publish((symbol_short!("rate_upd"),), event);
+    }
+
+    /// Cast an emergency vote for `currency` from an authorised `validator`.
+    ///
+    /// This is step 1 of the two-step emergency bypass flow (SC-025).  A validator
+    /// that believes a rate has genuinely moved beyond the per-currency emergency
+    /// threshold calls this function to register their vote.  Once `min_signatures`
+    /// distinct validators have cast qualifying votes for the same currency, any
+    /// validator may call [`Self::update_rate`] with the emergency rate to apply the
+    /// bypass.
+    ///
+    /// **This function always succeeds** (never panics on success path) so that the
+    /// vote is durably persisted in contract storage.  Votes expire after
+    /// `EMERGENCY_VOTE_TTL_SECONDS` (1 hour); stale votes are discarded before the
+    /// new vote is recorded.  Duplicate votes from the same validator for the same
+    /// currency replace the previous vote (no double-counting).
+    ///
+    /// Emits `EmergencyVoteCastEvent` with the current tally and required quorum.
+    pub fn cast_emergency_vote(
+        env: Env,
+        validator: Address,
+        currency: CurrencyCode,
+        rate: i128,
+    ) {
+        validator.require_auth();
+
+        // Validator must be in the authorised set.
+        let validator_set: Map<Address, bool> =
+            match env.storage().instance().get(&DATA_KEY.validator_set) {
+                Some(set) => set,
+                None => {
+                    let validators: Vec<Address> =
+                        env.storage().instance().get(&DATA_KEY.validators).unwrap();
+                    let mut set: Map<Address, bool> = Map::new(&env);
+                    for v in validators.iter() {
+                        set.set(v, true);
+                    }
+                    env.storage().instance().set(&DATA_KEY.validator_set, &set);
+                    set
+                }
+            };
+        if !validator_set.contains_key(validator.clone()) {
+            env.panic_with_error(OracleError::UnauthorizedValidator);
+        }
+
+        let min_sigs: u32 = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.min_signatures)
+            .unwrap();
+
+        let current_time = env.ledger().timestamp();
+
+        let mut all_votes: Map<CurrencyCode, Vec<EmergencyVote>> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.emergency_votes)
+            .unwrap_or(Map::new(&env));
+
+        let votes: Vec<EmergencyVote> = all_votes
+            .get(currency.clone())
+            .unwrap_or(Vec::new(&env));
+
+        // Discard expired and deduplicate same-validator votes.
+        let mut fresh_votes: Vec<EmergencyVote> = Vec::new(&env);
+        for v in votes.iter() {
+            let expired = current_time.saturating_sub(v.timestamp) > EMERGENCY_VOTE_TTL_SECONDS;
+            let is_same = v.validator == validator;
+            if !expired && !is_same {
+                fresh_votes.push_back(v.clone());
+            }
+        }
+        fresh_votes.push_back(EmergencyVote {
+            validator: validator.clone(),
+            rate,
+            timestamp: current_time,
+        });
+
+        let vote_count = fresh_votes.len();
+        all_votes.set(currency.clone(), fresh_votes);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.emergency_votes, &all_votes);
+        Self::extend_instance_ttl(&env);
+
+        env.events().publish(
+            (symbol_short!("emrg_vot"),),
+            EmergencyVoteCastEvent {
+                currency,
+                validator,
+                rate,
+                vote_count,
+                required: min_sigs,
+                timestamp: current_time,
+            },
+        );
+    }
+
+    /// Return the number of active (non-expired) emergency votes for `currency`.
+    pub fn get_emergency_vote_count(env: Env, currency: CurrencyCode) -> u32 {
+        let current_time = env.ledger().timestamp();
+        let all_votes: Map<CurrencyCode, Vec<EmergencyVote>> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.emergency_votes)
+            .unwrap_or(Map::new(&env));
+        let votes: Vec<EmergencyVote> = all_votes
+            .get(currency)
+            .unwrap_or(Vec::new(&env));
+        let mut count: u32 = 0;
+        for v in votes.iter() {
+            if current_time.saturating_sub(v.timestamp) <= EMERGENCY_VOTE_TTL_SECONDS {
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Admin override to set the rate for `currency` directly, bypassing validator
@@ -716,6 +899,73 @@ impl OracleContract {
             .instance()
             .set(&DATA_KEY.basket_weights, &basket_weights);
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Emergency threshold configuration (SC-025)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Set the per-currency emergency deviation threshold in basis points (admin only).
+    ///
+    /// When a validator submits a rate that deviates more than `threshold_bps`
+    /// from the stored rate, it is counted as an emergency vote rather than
+    /// immediately bypassing the time-lock.  The bypass only fires once
+    /// `min_signatures` validators have all cast qualifying votes.
+    ///
+    /// Pass `threshold_bps = 0` to reset the currency to the global default
+    /// ([`EMERGENCY_THRESHOLD_BPS`]).
+    pub fn set_emergency_threshold(env: Env, currency: CurrencyCode, threshold_bps: i128) {
+        Self::check_admin(&env);
+        // A threshold of 0 means "use the global default"; treat it the same as
+        // storing the default explicitly so readers always get a positive value.
+        let effective = if threshold_bps == 0 {
+            EMERGENCY_THRESHOLD_BPS
+        } else {
+            threshold_bps
+        };
+        let mut thresholds: Map<CurrencyCode, EmergencyConfig> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.emergency_thresholds)
+            .unwrap_or(Map::new(&env));
+        thresholds.set(currency, EmergencyConfig { threshold_bps: effective });
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.emergency_thresholds, &thresholds);
+    }
+
+    /// Return the emergency deviation threshold (in basis points) for `currency`.
+    ///
+    /// Falls back to the global [`EMERGENCY_THRESHOLD_BPS`] constant if no
+    /// per-currency override has been configured.
+    pub fn get_emergency_threshold(env: Env, currency: CurrencyCode) -> i128 {
+        Self::get_emergency_threshold_bps(&env, &currency)
+    }
+
+    /// Update the minimum number of validator signatures required for both
+    /// normal rate acceptance and emergency bypass consensus (admin only).
+    ///
+    /// `new_min` must be in `1..=validators.len()`.  Pending emergency votes are
+    /// cleared on change to avoid cross-quorum contamination.
+    pub fn set_min_signatures(env: Env, new_min: u32) {
+        Self::check_admin(&env);
+        let validators: Vec<Address> =
+            env.storage().instance().get(&DATA_KEY.validators).unwrap();
+        if new_min == 0 || new_min > validators.len() {
+            env.panic_with_error(OracleError::InvalidMinSignatures);
+        }
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.min_signatures, &new_min);
+        // Clear all pending emergency votes — they were cast under the old quorum.
+        let empty_votes: Map<CurrencyCode, Vec<EmergencyVote>> = Map::new(&env);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.emergency_votes, &empty_votes);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S-token config
+    // ─────────────────────────────────────────────────────────────────────────
 
     /// Set the S-token contract address backing `currency` (admin only).
     pub fn set_s_token_address(env: Env, currency: CurrencyCode, token_address: Address) {
@@ -1032,6 +1282,60 @@ impl OracleContract {
     // ─────────────────────────────────────────────────────────────────────────
     // Private helpers
     // ─────────────────────────────────────────────────────────────────────────
+
+    /// Return the effective emergency threshold (bps) for `currency`.
+    fn get_emergency_threshold_bps(env: &Env, currency: &CurrencyCode) -> i128 {
+        let thresholds: Map<CurrencyCode, EmergencyConfig> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.emergency_thresholds)
+            .unwrap_or(Map::new(env));
+        thresholds
+            .get(currency.clone())
+            .map(|cfg| cfg.threshold_bps)
+            .unwrap_or(EMERGENCY_THRESHOLD_BPS)
+    }
+
+    /// Check whether `>= min_sigs` non-expired emergency votes exist for `currency`.
+    ///
+    /// If consensus is reached, the vote list is cleared and `true` is returned.
+    /// Otherwise `false` is returned and votes are left intact.
+    fn check_and_consume_emergency_votes(
+        env: &Env,
+        currency: &CurrencyCode,
+        current_time: u64,
+        min_sigs: u32,
+        _rate: i128,
+    ) -> bool {
+        let mut all_votes: Map<CurrencyCode, Vec<EmergencyVote>> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.emergency_votes)
+            .unwrap_or(Map::new(env));
+
+        let votes: Vec<EmergencyVote> = all_votes
+            .get(currency.clone())
+            .unwrap_or(Vec::new(env));
+
+        // Count only non-expired votes.
+        let mut live_count: u32 = 0;
+        for v in votes.iter() {
+            if current_time.saturating_sub(v.timestamp) <= EMERGENCY_VOTE_TTL_SECONDS {
+                live_count += 1;
+            }
+        }
+
+        if live_count >= min_sigs {
+            // Consume the votes — clear them so they can't be reused.
+            all_votes.remove(currency.clone());
+            env.storage()
+                .instance()
+                .set(&DATA_KEY.emergency_votes, &all_votes);
+            true
+        } else {
+            false
+        }
+    }
 
     fn get_rate_internal(env: &Env, currency: &CurrencyCode) -> Option<RateData> {
         Self::extend_instance_ttl(env);

--- a/acbu_oracle/tests/test_comprehensive.rs
+++ b/acbu_oracle/tests/test_comprehensive.rs
@@ -253,9 +253,14 @@ fn test_update_rate_before_interval_fails() {
 
 #[test]
 fn test_update_rate_with_emergency_deviation_bypasses_interval() {
+    // SC-025: A single validator can no longer unilaterally bypass the update interval.
+    // The bypass now requires N-of-M (min_signatures) validators to first call
+    // cast_emergency_vote, and then any validator may call update_rate to commit.
+    // setup() initialises min_signatures = 2, so two validators must agree.
     let (env, client, _contract_id, _admin, validators) = setup();
 
     let validator = validators.get(0).unwrap();
+    let validator2 = validators.get(1).unwrap();
     let ngn = CurrencyCode::new(&env, "NGN");
     let initial_rate = 1_000_000i128;
     let mut sources = Vec::new(&env);
@@ -263,7 +268,7 @@ fn test_update_rate_with_emergency_deviation_bypasses_interval() {
     sources.push_back(1_000_000i128);
     sources.push_back(1_000_000i128);
 
-    // First update
+    // Seed an initial rate.
     client.update_rate(
         &validator,
         &ngn,
@@ -272,15 +277,19 @@ fn test_update_rate_with_emergency_deviation_bypasses_interval() {
         &env.ledger().timestamp(),
     );
 
-    // Try to update with emergency deviation (>5%)
-    env.ledger().with_mut(|l| l.timestamp += 1000); // Only 1000 seconds later
-    let emergency_rate = 1_060_000i128; // 6% higher
+    // Advance only 1000 seconds — well within the 6h update interval.
+    env.ledger().with_mut(|l| l.timestamp += 1000);
+    let emergency_rate = 1_060_000i128; // 6% above threshold (>5%)
     let mut emergency_sources = Vec::new(&env);
     emergency_sources.push_back(1_060_000i128);
     emergency_sources.push_back(1_060_000i128);
     emergency_sources.push_back(1_060_000i128);
 
-    // Should succeed despite interval not met
+    // Step 1: Both validators cast emergency votes.
+    client.cast_emergency_vote(&validator, &ngn, &emergency_rate);
+    client.cast_emergency_vote(&validator2, &ngn, &emergency_rate);
+
+    // Step 2: Now consensus is met (2-of-3) — update_rate grants the bypass.
     client.update_rate(
         &validator,
         &ngn,
@@ -290,7 +299,7 @@ fn test_update_rate_with_emergency_deviation_bypasses_interval() {
     );
 
     let stored_rate = client.get_rate(&ngn);
-    assert_eq!(stored_rate, 1_060_000, "stored_rate should equal 1_060_000");
+    assert_eq!(stored_rate, 1_060_000, "stored_rate should equal 1_060_000 after 2-of-3 consensus");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/acbu_oracle/tests/test_emergency_threshold.rs
+++ b/acbu_oracle/tests/test_emergency_threshold.rs
@@ -1,0 +1,577 @@
+//! SC-025 — Tests for per-currency configurable emergency threshold and N-of-M
+//! consensus requirement during emergency bypasses.
+//!
+//! Prior to this fix a single validator could bypass the UPDATE_INTERVAL timelock
+//! by submitting a rate that deviated more than `EMERGENCY_THRESHOLD_BPS` (5 %) from
+//! the stored rate. These tests verify:
+//!
+//!  1. A single validator cannot bypass the interval alone (needs N-of-M votes).
+//!  2. The bypass fires correctly once `min_signatures` validators have cast votes.
+//!  3. Per-currency thresholds override the global default.
+//!  4. Stale votes are discarded and do not count towards consensus.
+//!  5. Duplicate votes from the same validator are replaced (not double-counted).
+//!  6. `set_emergency_threshold` and `get_emergency_threshold` behave correctly.
+//!  7. `set_min_signatures` updates the quorum and clears stale votes.
+//!  8. Normal (non-emergency) rate updates are unaffected.
+//!  9. Per-currency vote buckets are independent.
+
+#![cfg(test)]
+
+use acbu_oracle::{OracleContract, OracleContractClient};
+use shared::CurrencyCode;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env, Map, Vec,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Standard update interval used by the oracle (6 h).
+const UPDATE_INTERVAL: u64 = 21_600;
+/// Emergency vote TTL (1 h).
+const EMERGENCY_VOTE_TTL: u64 = 3_600;
+
+fn make_ledger(timestamp: u64, seq: u32) -> LedgerInfo {
+    LedgerInfo {
+        timestamp,
+        protocol_version: 20,
+        sequence_number: seq,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3_110_400,
+    }
+}
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.ledger().set(make_ledger(1_000_000, 100));
+    env
+}
+
+fn advance_time(env: &Env, delta: u64) {
+    let now = env.ledger().timestamp();
+    let seq = env.ledger().sequence();
+    env.ledger().set(make_ledger(now + delta, seq + 1));
+}
+
+fn single_source(env: &Env, rate: i128) -> Vec<i128> {
+    let mut v = Vec::new(env);
+    v.push_back(rate);
+    v
+}
+
+/// Initialise an oracle with N validators and min_signatures = `min_sigs`.
+fn setup_with(
+    n_validators: usize,
+    min_sigs: u32,
+) -> (
+    Env,
+    Address,
+    Vec<Address>,
+    CurrencyCode,
+    OracleContractClient<'static>,
+) {
+    let env = make_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    for _ in 0..n_validators {
+        validators.push_back(Address::generate(&env));
+    }
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    let mut weights: Map<CurrencyCode, i128> = Map::new(&env);
+    weights.set(ngn.clone(), 10_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &min_sigs, &currencies, &weights);
+
+    (env, admin, validators, ngn, client)
+}
+
+/// Write an initial rate via a single validator source (no interval check needed
+/// for the first ever write).
+fn seed_rate(
+    env: &Env,
+    client: &OracleContractClient,
+    validator: &Address,
+    currency: &CurrencyCode,
+    rate: i128,
+) {
+    client.update_rate(validator, currency, &rate, &single_source(env, rate), &0u64);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Single validator cannot bypass without N-of-M votes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Without any prior `cast_emergency_vote` calls, submitting an emergency-magnitude
+/// rate within the interval falls through to `UpdateIntervalNotMet` (#7008).
+#[test]
+#[should_panic(expected = "#7008")]
+fn test_single_validator_cannot_bypass_alone_no_votes() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    // 10% deviation but zero votes cast — should fall through to interval check.
+    let emergency_rate = 1_100_000i128;
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+}
+
+/// With only 1 vote cast but min_sigs = 2, the bypass is not granted.
+#[test]
+#[should_panic(expected = "#7008")]
+fn test_one_vote_insufficient_for_bypass() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_100_000i128;
+    // Cast only 1 vote (v0).
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 1u32);
+
+    // Attempting the rate update without full consensus fails.
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+}
+
+/// With min_signatures = 1, a single vote is sufficient to bypass (degenerate case).
+#[test]
+fn test_single_validator_can_bypass_with_min_1() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 1);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_100_000i128;
+    // Cast one vote and immediately update.
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), emergency_rate);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. N-of-M consensus grants the bypass
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Two validators cast votes → consensus reached → bypass fires.
+#[test]
+fn test_two_of_three_consensus_grants_bypass() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+    let v1 = validators.get(1).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_200_000i128; // 20% deviation
+
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 1u32, "should have 1 vote");
+
+    client.cast_emergency_vote(&v1, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 2u32, "should have 2 votes");
+
+    // Bypass granted — only one validator needs to call update_rate to commit.
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), emergency_rate);
+
+    // After the bypass, votes are consumed.
+    assert_eq!(client.get_emergency_vote_count(&ngn), 0u32, "votes should be cleared after bypass");
+}
+
+/// Three-of-five: bypass fires only after the third vote.
+#[test]
+fn test_three_of_five_consensus_grants_bypass() {
+    let (env, _admin, validators, ngn, client) = setup_with(5, 3);
+    let v0 = validators.get(0).unwrap();
+    let v1 = validators.get(1).unwrap();
+    let v2 = validators.get(2).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_300_000i128; // 30% deviation
+
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    client.cast_emergency_vote(&v1, &ngn, &emergency_rate);
+
+    // 2 votes, need 3 — bypass not yet available.
+    assert!(
+        client
+            .try_update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64)
+            .is_err(),
+        "2 votes insufficient for 3-of-5"
+    );
+
+    client.cast_emergency_vote(&v2, &ngn, &emergency_rate);
+
+    // 3 votes — bypass fires.
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), emergency_rate);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Stale vote expiry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Votes older than the vote TTL are not counted toward consensus.
+#[test]
+#[should_panic(expected = "#7008")]
+fn test_expired_votes_do_not_count() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+    let v1 = validators.get(1).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_200_000i128;
+
+    // v0 casts a vote that will later expire.
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 1u32);
+
+    // More than 1 h passes — v0's vote expires.
+    advance_time(&env, EMERGENCY_VOTE_TTL + 1);
+
+    // v1 casts a vote, but v0's is stale → only 1 live vote → insufficient.
+    client.cast_emergency_vote(&v1, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 1u32, "expired vote not counted");
+
+    // Attempting bypass with only 1 live vote fails.
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Duplicate votes do not double-count
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The same validator calling `cast_emergency_vote` twice counts as 1 vote.
+#[test]
+fn test_duplicate_vote_does_not_increase_count() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_200_000i128;
+
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate); // duplicate
+    assert_eq!(
+        client.get_emergency_vote_count(&ngn),
+        1u32,
+        "duplicate vote must not count twice"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Per-currency threshold configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Default threshold is 500 bps (5%).
+#[test]
+fn test_default_threshold_is_500bps() {
+    let (_env, _admin, _validators, ngn, client) = setup_with(3, 2);
+    assert_eq!(client.get_emergency_threshold(&ngn), 500i128);
+}
+
+/// `set_emergency_threshold` persists and `get_emergency_threshold` reads it back.
+#[test]
+fn test_set_and_get_emergency_threshold() {
+    let (_env, _admin, _validators, ngn, client) = setup_with(3, 2);
+    client.set_emergency_threshold(&ngn, &1_000i128);
+    assert_eq!(client.get_emergency_threshold(&ngn), 1_000i128);
+}
+
+/// Passing 0 to `set_emergency_threshold` resets to the global default (500 bps).
+#[test]
+fn test_set_threshold_zero_resets_to_default() {
+    let (_env, _admin, _validators, ngn, client) = setup_with(3, 2);
+    client.set_emergency_threshold(&ngn, &1_500i128);
+    client.set_emergency_threshold(&ngn, &0i128);
+    assert_eq!(client.get_emergency_threshold(&ngn), 500i128);
+}
+
+/// A stricter per-currency threshold (1000 bps / 10%) means a 6% deviation is
+/// NOT an emergency — the update is blocked by the interval lock without votes.
+#[test]
+#[should_panic(expected = "#7008")]
+fn test_stricter_threshold_blocks_6pct_deviation() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    client.set_emergency_threshold(&ngn, &1_000i128); // 10% threshold
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    // 6% deviation — below 10% threshold → normal interval check fires.
+    let rate_6pct = 1_060_000i128;
+    client.update_rate(&v0, &ngn, &rate_6pct, &single_source(&env, rate_6pct), &0u64);
+}
+
+/// A permissive per-currency threshold (200 bps / 2%) means a 3% deviation triggers
+/// the emergency vote path. Without sufficient votes, bypass is not granted.
+#[test]
+#[should_panic(expected = "#7008")]
+fn test_permissive_threshold_needs_votes_for_3pct_deviation() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    client.set_emergency_threshold(&ngn, &200i128); // 2% threshold
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    // 3% deviation (300 bps) exceeds the 2% threshold — emergency path — but no votes.
+    let rate_3pct = 1_030_000i128;
+    client.update_rate(&v0, &ngn, &rate_3pct, &single_source(&env, rate_3pct), &0u64);
+}
+
+/// With a permissive threshold (2%), N-of-M votes on a 3% move allow the bypass.
+#[test]
+fn test_permissive_threshold_2_votes_allow_3pct_bypass() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+    let v1 = validators.get(1).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    client.set_emergency_threshold(&ngn, &200i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let rate_3pct = 1_030_000i128;
+    client.cast_emergency_vote(&v0, &ngn, &rate_3pct);
+    client.cast_emergency_vote(&v1, &ngn, &rate_3pct);
+
+    client.update_rate(&v0, &ngn, &rate_3pct, &single_source(&env, rate_3pct), &0u64);
+    assert_eq!(client.get_rate(&ngn), rate_3pct);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. set_min_signatures
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// After `set_min_signatures`, the new quorum is respected and pending votes
+/// accumulated under the old quorum are cleared.
+#[test]
+fn test_set_min_signatures_clears_pending_votes() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 3);
+    let v0 = validators.get(0).unwrap();
+    let v1 = validators.get(1).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emergency_rate = 1_200_000i128;
+
+    // Two votes cast under quorum = 3.
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    client.cast_emergency_vote(&v1, &ngn, &emergency_rate);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 2u32);
+
+    // Admin lowers quorum to 2 — pending votes must be cleared.
+    client.set_min_signatures(&2u32);
+    assert_eq!(client.get_min_signatures(), 2u32);
+    assert_eq!(client.get_emergency_vote_count(&ngn), 0u32, "set_min_signatures must clear pending votes");
+
+    // v0 needs to re-cast (still 1 vote), bypass not available yet.
+    client.cast_emergency_vote(&v0, &ngn, &emergency_rate);
+    assert!(
+        client
+            .try_update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64)
+            .is_err(),
+        "1 vote not enough for quorum 2"
+    );
+
+    // v1 re-casts — now 2 votes, consensus with new quorum = 2.
+    client.cast_emergency_vote(&v1, &ngn, &emergency_rate);
+    client.update_rate(&v0, &ngn, &emergency_rate, &single_source(&env, emergency_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), emergency_rate);
+}
+
+/// `set_min_signatures` with 0 panics with InvalidMinSignatures (#7002).
+#[test]
+#[should_panic(expected = "#7002")]
+fn test_set_min_signatures_zero_panics() {
+    let (_env, _admin, _validators, _ngn, client) = setup_with(3, 2);
+    client.set_min_signatures(&0u32);
+}
+
+/// `set_min_signatures` exceeding the validator count panics with #7002.
+#[test]
+#[should_panic(expected = "#7002")]
+fn test_set_min_signatures_exceeds_count_panics() {
+    let (_env, _admin, validators, _ngn, client) = setup_with(3, 2);
+    client.set_min_signatures(&(validators.len() + 1));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Normal updates are unaffected
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// After the full update interval, any rate change works without votes.
+#[test]
+fn test_normal_update_after_interval_succeeds() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL + 1);
+
+    let new_rate = 1_010_000i128; // 1% move
+    client.update_rate(&v0, &ngn, &new_rate, &single_source(&env, new_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), new_rate);
+}
+
+/// A large move (>5%) after the interval passes is not an emergency — no votes needed.
+#[test]
+fn test_large_move_after_interval_is_normal() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL + 1);
+
+    let new_rate = 1_200_000i128; // 20% move — interval already passed
+    client.update_rate(&v0, &ngn, &new_rate, &single_source(&env, new_rate), &0u64);
+    assert_eq!(client.get_rate(&ngn), new_rate);
+}
+
+/// First-ever rate write for a currency is never subject to emergency checks.
+#[test]
+fn test_first_rate_write_never_blocked() {
+    let (env, _admin, validators, ngn, client) = setup_with(3, 2);
+    let v0 = validators.get(0).unwrap();
+    client.update_rate(&v0, &ngn, &999_999i128, &single_source(&env, 999_999i128), &0u64);
+    assert_eq!(client.get_rate(&ngn), 999_999i128);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Per-currency vote buckets are independent
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emergency votes for NGN must not pollute the KES vote count.
+#[test]
+fn test_votes_are_independent_per_currency() {
+    let env = make_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let v0 = Address::generate(&env);
+    let v1 = Address::generate(&env);
+    let mut validators = Vec::new(&env);
+    validators.push_back(v0.clone());
+    validators.push_back(v1.clone());
+
+    let ngn = CurrencyCode::new(&env, "NGN");
+    let kes = CurrencyCode::new(&env, "KES");
+    let mut currencies = Vec::new(&env);
+    currencies.push_back(ngn.clone());
+    currencies.push_back(kes.clone());
+    let mut weights: Map<CurrencyCode, i128> = Map::new(&env);
+    weights.set(ngn.clone(), 5_000i128);
+    weights.set(kes.clone(), 5_000i128);
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &validators, &2u32, &currencies, &weights);
+
+    seed_rate(&env, &client, &v0, &ngn, 1_000_000i128);
+    seed_rate(&env, &client, &v0, &kes, 1_000_000i128);
+    advance_time(&env, UPDATE_INTERVAL / 2);
+
+    let emrg = 1_200_000i128;
+
+    // NGN votes.
+    client.cast_emergency_vote(&v0, &ngn, &emrg);
+    client.cast_emergency_vote(&v1, &ngn, &emrg);
+
+    // KES votes.
+    client.cast_emergency_vote(&v0, &kes, &emrg);
+
+    // NGN has 2 votes → bypass available.
+    client.update_rate(&v0, &ngn, &emrg, &single_source(&env, emrg), &0u64);
+    assert_eq!(client.get_rate(&ngn), emrg, "NGN should be updated");
+
+    // KES still has only 1 vote — bypass not yet available.
+    assert!(
+        client
+            .try_update_rate(&v0, &kes, &emrg, &single_source(&env, emrg), &0u64)
+            .is_err(),
+        "KES should still need another vote"
+    );
+
+    // Add second KES vote.
+    client.cast_emergency_vote(&v1, &kes, &emrg);
+    client.update_rate(&v0, &kes, &emrg, &single_source(&env, emrg), &0u64);
+    assert_eq!(client.get_rate(&kes), emrg, "KES should be updated");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Admin-only enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Non-admin callers must not be able to set the emergency threshold.
+#[test]
+#[should_panic]
+fn test_set_emergency_threshold_requires_admin() {
+    let (env, _admin, _validators, ngn, client) = setup_with(3, 2);
+    let attacker = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &attacker,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_emergency_threshold",
+            args: soroban_sdk::IntoVal::into_val(&(ngn.clone(), 1_000i128), &env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_emergency_threshold(&ngn, &1_000i128);
+}
+
+/// Non-admin callers must not be able to call `set_min_signatures`.
+#[test]
+#[should_panic]
+fn test_set_min_signatures_requires_admin() {
+    let (env, _admin, _validators, _ngn, client) = setup_with(3, 2);
+    let attacker = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &attacker,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_min_signatures",
+            args: soroban_sdk::IntoVal::into_val(&(1u32,), &env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_min_signatures(&1u32);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Unauthorised validator cannot cast emergency votes
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "#7007")]
+fn test_unauthorized_validator_cannot_cast_vote() {
+    let (env, _admin, _validators, ngn, client) = setup_with(3, 2);
+    let rogue = Address::generate(&env);
+    client.cast_emergency_vote(&rogue, &ngn, &1_100_000i128);
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -210,6 +210,55 @@ pub struct OutlierDetectionEvent {
     pub timestamp: u64,
 }
 
+/// A single validator's emergency-bypass vote for a currency pair.
+///
+/// When a validator submits a rate that exceeds the per-currency emergency
+/// threshold it is recorded here.  Once `min_signatures` validators have cast
+/// votes, the time-lock bypass is granted and the pending votes are cleared.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EmergencyVote {
+    /// The validator who submitted the candidate rate.
+    pub validator: Address,
+    /// The proposed rate (7 decimals).
+    pub rate: i128,
+    /// Ledger timestamp of the submission (used to expire stale votes).
+    pub timestamp: u64,
+}
+
+/// Per-currency emergency bypass configuration stored in oracle instance storage.
+///
+/// Allows operators to tune the threshold per currency pair so that naturally
+/// more-volatile currencies (e.g. ZWL, SSP) do not trigger false-positive
+/// emergency bypasses while still catching genuine crises in stable pairs.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EmergencyConfig {
+    /// Deviation in basis points that triggers an emergency vote.
+    /// Defaults to [`EMERGENCY_THRESHOLD_BPS`] (500 bps = 5 %).
+    pub threshold_bps: i128,
+}
+
+/// Event emitted when an emergency vote is cast (validator requests bypass).
+#[contracttype]
+pub struct EmergencyVoteCastEvent {
+    pub currency: CurrencyCode,
+    pub validator: Address,
+    pub rate: i128,
+    pub vote_count: u32,
+    pub required: u32,
+    pub timestamp: u64,
+}
+
+/// Event emitted when enough emergency votes accumulate and the bypass fires.
+#[contracttype]
+pub struct EmergencyBypassEvent {
+    pub currency: CurrencyCode,
+    pub new_rate: i128,
+    pub vote_count: u32,
+    pub timestamp: u64,
+}
+
 /// Error types for the **burning** contract (and any crate that re-uses this enum).
 ///
 /// Numeric codes are stable for client UX; see `docs/ERROR_CODES.md` in the workspace root.


### PR DESCRIPTION
…nsensus

EMERGENCY_THRESHOLD_BPS (5%) was a single global constant that allowed any one validator to bypass the 6-hour UPDATE_INTERVAL by submitting a rate that deviated more than 5% from the stored value. For volatile basket currencies (ZWL, SSP, etc.) that can legitimately move >5% intraday, this meant a single compromised or errant validator could bypass safety timelocks unilaterally.

Changes:
- shared/src/lib.rs: add EmergencyVote, EmergencyConfig, EmergencyVoteCastEvent, EmergencyBypassEvent contracttypes for storing per-currency emergency votes and emitting audit events.

- acbu_oracle/src/lib.rs:
  * Add DataKey fields: emergency_thresholds, emergency_votes
  * Add OracleError::InsufficientEmergencyVotes (7025)
  * Add EMERGENCY_VOTE_TTL_SECONDS = 3600 (1 hour vote expiry)
  * New public functions:
    - cast_emergency_vote(validator, currency, rate): step 1 of the two-step bypass flow — always succeeds, durably persists the vote so it survives as on-chain state.
    - get_emergency_vote_count(currency): returns live (non-expired) vote count for a currency pair.
    - set_emergency_threshold(currency, bps): admin sets per-pair threshold (0 resets to global default of 500 bps).
    - get_emergency_threshold(currency): returns effective threshold.
    - set_min_signatures(new_min): admin updates quorum; clears stale votes to prevent cross-quorum contamination.
  * update_rate(): only grants the emergency bypass when
    >= min_signatures live votes exist in the vote map. If consensus
    is not yet reached, the request falls through to the normal interval check (UpdateIntervalNotMet).
  * private check_and_consume_emergency_votes(): reads vote map, counts live votes, clears them on consensus, returns bool.
  * private get_emergency_threshold_bps(): per-currency threshold lookup with global-default fallback.

Two-step flow (SC-025):
  1. Each validator that believes a move is genuine calls cast_emergency_vote() — this always succeeds, so storage writes persist even across other failed transactions.
  2. Once min_signatures votes exist, any validator calls update_rate() with the emergency rate and the bypass is granted.

- acbu_oracle/tests/test_emergency_threshold.rs: 23 new tests covering all aspects of the fix (N-of-M flow, vote expiry, deduplication, per-currency thresholds, quorum update, admin-only enforcement, etc.)

- acbu_oracle/tests/test_comprehensive.rs: update test_update_rate_with_emergency_deviation_bypasses_interval to use the two-step flow (cast_emergency_vote x2 then update_rate).

closes #528 