### PR TITLE
Error code numbering collides between shared and contract-specific enums

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -136,15 +136,6 @@ pub struct RepaymentEvent {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum Error {
-    NotFound = 1,
-    InvalidState = 2,
-    Unauthorized = 3,
-    AlreadyInitialized = 4,
-    InvalidAmount = 5,
-    InsufficientBalance = 6,
-    InsufficientCollateral = 7,
-    InsufficientLiquidity = 8,
-    DustBalance = 9,
     Paused = 2001,
     InvalidVersion = 2002,
     TimelockNotElapsed = 2003,
@@ -152,6 +143,15 @@ pub enum Error {
     NoPendingAdmin = 2005,
     AdminTimelockNotElapsed = 2006,
     NoPendingAdminToCancel = 2007,
+    NotFound = 2008,
+    InvalidState = 2009,
+    Unauthorized = 2010,
+    AlreadyInitialized = 2011,
+    InvalidAmount = 2012,
+    InsufficientBalance = 2013,
+    InsufficientCollateral = 2014,
+    InsufficientLiquidity = 2015,
+    DustBalance = 2016,
     Unknown = 2999,
 }
 

--- a/acbu_multisig/src/lib.rs
+++ b/acbu_multisig/src/lib.rs
@@ -40,10 +40,6 @@ use shared::{
     ProposalExecutedEvent, DataKey as SharedDataKey, CONTRACT_VERSION,
 };
 
-mod shared {
-    pub use shared::*;
-}
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -77,19 +73,19 @@ pub enum DataKey {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    Unauthorized = 3,
-    ProposalNotFound = 4,
-    AlreadyApproved = 5,
-    AlreadyExecuted = 6,
-    Expired = 7,
-    ThresholdNotMet = 8,
-    InvalidThreshold = 9,
-    TooManySigners = 10,
-    EmptySigners = 11,
-    DuplicateSigner = 12,
-    Unknown = 999,
+    AlreadyInitialized = 4001,
+    NotInitialized = 4002,
+    Unauthorized = 4003,
+    ProposalNotFound = 4004,
+    AlreadyApproved = 4005,
+    AlreadyExecuted = 4006,
+    Expired = 4007,
+    ThresholdNotMet = 4008,
+    InvalidThreshold = 4009,
+    TooManySigners = 4010,
+    EmptySigners = 4011,
+    DuplicateSigner = 4012,
+    Unknown = 4999,
 }
 
 impl Display for Error {

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -35,19 +35,19 @@ Clients map `invoke_contract` / simulation failures using the contract error `u3
 
 | Code | Variant | Description |
 | ---: | --- | --- |
-| 1 | `AlreadyInitialized` | multisig already initialized |
-| 2 | `NotInitialized` | multisig not initialized |
-| 3 | `Unauthorized` | unauthorized |
-| 4 | `ProposalNotFound` | proposal not found |
-| 5 | `AlreadyApproved` | proposal already approved |
-| 6 | `AlreadyExecuted` | proposal already executed |
-| 7 | `Expired` | proposal expired |
-| 8 | `ThresholdNotMet` | approval threshold not met |
-| 9 | `InvalidThreshold` | invalid threshold |
-| 10 | `TooManySigners` | too many signers |
-| 11 | `EmptySigners` | signers list cannot be empty |
-| 12 | `DuplicateSigner` | duplicate signer |
-| 999 | `Unknown` | unknown multisig error |
+| 4001 | `AlreadyInitialized` | multisig already initialized |
+| 4002 | `NotInitialized` | multisig not initialized |
+| 4003 | `Unauthorized` | unauthorized |
+| 4004 | `ProposalNotFound` | proposal not found |
+| 4005 | `AlreadyApproved` | proposal already approved |
+| 4006 | `AlreadyExecuted` | proposal already executed |
+| 4007 | `Expired` | proposal expired |
+| 4008 | `ThresholdNotMet` | approval threshold not met |
+| 4009 | `InvalidThreshold` | invalid threshold |
+| 4010 | `TooManySigners` | too many signers |
+| 4011 | `EmptySigners` | signers list cannot be empty |
+| 4012 | `DuplicateSigner` | duplicate signer |
+| 4999 | `Unknown` | unknown multisig error |
 
 ## `acbu_savings_vault` - `Error`
 
@@ -80,15 +80,6 @@ Clients map `invoke_contract` / simulation failures using the contract error `u3
 
 | Code | Variant | Description |
 | ---: | --- | --- |
-| 1 | `NotFound` | resource not found |
-| 2 | `InvalidState` | invalid lending pool state |
-| 3 | `Unauthorized` | unauthorized |
-| 4 | `AlreadyInitialized` | lending pool already initialized |
-| 5 | `InvalidAmount` | invalid amount |
-| 6 | `InsufficientBalance` | insufficient balance |
-| 7 | `InsufficientCollateral` | insufficient collateral |
-| 8 | `InsufficientLiquidity` | insufficient liquidity |
-| 9 | `DustBalance` | dust balance |
 | 2001 | `Paused` | lending pool is paused |
 | 2002 | `InvalidVersion` | invalid contract version |
 | 2003 | `TimelockNotElapsed` | timelock has not elapsed |
@@ -96,6 +87,15 @@ Clients map `invoke_contract` / simulation failures using the contract error `u3
 | 2005 | `NoPendingAdmin` | no pending admin |
 | 2006 | `AdminTimelockNotElapsed` | admin timelock has not elapsed |
 | 2007 | `NoPendingAdminToCancel` | no pending admin to cancel |
+| 2008 | `NotFound` | resource not found |
+| 2009 | `InvalidState` | invalid lending pool state |
+| 2010 | `Unauthorized` | unauthorized |
+| 2011 | `AlreadyInitialized` | lending pool already initialized |
+| 2012 | `InvalidAmount` | invalid amount |
+| 2013 | `InsufficientBalance` | insufficient balance |
+| 2014 | `InsufficientCollateral` | insufficient collateral |
+| 2015 | `InsufficientLiquidity` | insufficient liquidity |
+| 2016 | `DustBalance` | dust balance |
 | 2999 | `Unknown` | unknown lending pool error |
 
 ## `acbu_escrow` - `EscrowError`


### PR DESCRIPTION
1. Error code collisions — acbu_multisig::Error renumbered from 1–12/999 to 4001–4012/4999 (its own dedicated range, matching the per-contract numbering scheme already used by acbu_savings_vault (1000s), acbu_escrow (3000s), acbu_minting (5000s), etc.). acbu_lending_pool::Error's colliding 1–9 variants (NotFound, InvalidState, Unauthorized, AlreadyInitialized, InvalidAmount, InsufficientBalance, InsufficientCollateral, InsufficientLiquidity, DustBalance) were moved to 2008–2016, filling out its existing 2000-range block alongside the already-non-colliding Paused/InvalidVersion/timelock variants. No code now collides with shared::ContractError's 1–15 range or with each other. docs/ERROR_CODES.md updated to match (regenerating via scripts/generate_error_codes.py also surfaced unrelated pre-existing drift from other merged PRs — including a genuine duplicate-code bug in acbu_reserve_tracker at 8008–8010 — which I left untouched as out of scope and hand-patched only the two relevant sections).
2. Ambiguous shared re-export — removed the local mod shared { pub use shared::*; } block in acbu_multisig/src/lib.rs. It wasn't referenced anywhere (the file already imports what it needs via use shared::{...} at the top), so it was pure dead code creating a name clash between the crate-root module and the shared crate.

Only variant names are referenced elsewhere (tests use Error::Variant matching, never raw numeric codes), so this renumbering doesn't break anything downstream in-repo. Not run/tested per your instruction.



closes #490
closes #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Standardized lending pool error codes to the `2001–2016` range.
  * Standardized multisig error codes to the `4001–4012` range, with unknown errors using `4999`.
  * Existing error messages and behaviors remain unchanged.

* **Documentation**
  * Updated the error-code reference to reflect the new lending pool and multisig mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->