### PR TITLE
fix(minting): add assert_recipient_is_account in mint_from_fiat

### DIFF
--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -860,6 +860,10 @@ impl MintingContract {
         }
         operator.require_auth();
 
+        // C-058: reject contract-type recipients — minting to a contract address
+        // that has no token-receipt logic would permanently strand the funds.
+        assert_recipient_is_account(&recipient);
+
         // C-039: Strict input validation — enforce length bounds and charset
         // before touching any storage, so garbage IDs are rejected cheaply.
         validate_fintech_tx_id(&env, &fintech_tx_id);


### PR DESCRIPTION
Every other mint function rejects contract-type recipients via assert_recipient_is_account() to prevent permanently stranding ACBU funds. mint_from_fiat was missing this guard.

Add the check immediately after operator.require_auth(), matching the placement in the other operator-initiated mint functions.

closes #469 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure minting recipients are valid account addresses.
  * Contract-type recipient addresses are now rejected before transaction validation proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->