### PR TITLE
fix(oracle): replace hardcoded 10_000 with BASIS_POINTS in get_acbu_u…

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -665,7 +665,7 @@ impl OracleContract {
             if let Some(weight) = basket_weights.get(currency.clone()) {
                 if let Some(rate_data) = Self::get_rate_internal(&env, &currency) {
                     Self::assert_rate_fresh(&env, &rate_data, &currency);
-                    let contribution = (rate_data.rate_usd * weight) / 10_000;
+                    let contribution = (rate_data.rate_usd * weight) / BASIS_POINTS;
                     weighted_sum += contribution;
                     total_weight += weight;
                 }
@@ -676,7 +676,7 @@ impl OracleContract {
             env.panic_with_error(OracleError::RateNotInitialized);
         }
 
-        (weighted_sum * 10_000) / total_weight
+        (weighted_sum * BASIS_POINTS) / total_weight
     }
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…sd_rate

get_acbu_usd_rate used the literal 10_000 for both the per-currency contribution and the final normalization, while the equivalent timestamped function get_acbu_usd_rate_with_timestamp already used BASIS_POINTS. If the BASIS_POINTS constant ever changes the two functions would silently diverge and return different ACBU/USD rates.

Replace both occurrences of 10_000 with BASIS_POINTS.

closes #470 