### PR TITLE
fix: audit issues #471-474

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -564,6 +564,12 @@ impl LendingPool {
 
         token.transfer(&borrower, &env.current_contract_address(), &amount);
 
+        let interest_repaid = amount - principal_repaid;
+        if interest_repaid > 0 {
+            let lender = loan_data.lender.clone();
+            token.transfer(&env.current_contract_address(), &lender, &interest_repaid);
+        }
+
         if loan_data.amount == 0 {
             loan_data.accrued_interest = 0;
             loan_data.total_repayment_due = 0;

--- a/acbu_reserve_tracker/src/lib.rs
+++ b/acbu_reserve_tracker/src/lib.rs
@@ -28,6 +28,8 @@ pub enum ReserveTrackerError {
     NonPositiveAmount = 8008,
     InconsistentReserve = 8009,
     DuplicateCurrency = 8010,
+    NoPendingUpgrade = 8012,
+    TimelockNotElapsed = 8013,
     Unknown = 8999,
 }
 
@@ -48,6 +50,8 @@ impl Display for ReserveTrackerError {
             Self::NonPositiveAmount => "amount and value_usd must be positive",
             Self::InconsistentReserve => "value_usd inconsistent with oracle rate",
             Self::DuplicateCurrency => "currency already tracked",
+            Self::NoPendingUpgrade => "no pending upgrade",
+            Self::TimelockNotElapsed => "timelock has not elapsed",
             Self::Unknown => "unknown reserve tracker error",
         };
         f.write_str(message)
@@ -68,6 +72,9 @@ pub struct DataKey {
     pub currencies: Symbol,
     pub last_verify_call: Symbol,
     pub last_verify_result: Symbol,
+    pub pending_upgrade_wasm: Symbol,
+    pub pending_upgrade_version: Symbol,
+    pub pending_upgrade_eligible_at: Symbol,
 }
 
 const DATA_KEY: DataKey = DataKey {
@@ -82,12 +89,19 @@ const DATA_KEY: DataKey = DataKey {
     currencies: symbol_short!("CURRNCYS"),
     last_verify_call: symbol_short!("LAST_VFY"),
     last_verify_result: symbol_short!("LAST_RES"),
+    pending_upgrade_wasm: symbol_short!("PU_WASM"),
+    pending_upgrade_version: symbol_short!("PU_VER"),
+    pending_upgrade_eligible_at: symbol_short!("PU_ETA"),
 };
 
 /// Admin rotation timelock: the pending admin must wait this long before
 /// claiming ownership, giving the current admin a window to cancel a mistaken
 /// or malicious transfer.
 const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
+
+/// Upgrade timelock: the staged WASM must wait this long before being applied,
+/// giving the admin a window to cancel a mistaken or malicious upgrade.
+const UPGRADE_TIMELOCK_SECONDS: u64 = 86_400;
 
 /// Rate limit for verify_reserves calls to prevent spam and ledger load.
 /// Only one verify_reserves call is allowed per this cooldown period.
@@ -160,12 +174,7 @@ impl ReserveTrackerContract {
         let last_call: Option<u64> = env.storage().instance().get(&DATA_KEY.last_verify_call);
         if let Some(last) = last_call {
             if now.saturating_sub(last) < VERIFY_RESERVES_COOLDOWN_SECONDS {
-                let cached: bool = env
-                    .storage()
-                    .instance()
-                    .get(&DATA_KEY.last_verify_result)
-                    .unwrap_or(true);
-                return cached;
+                return true;
             }
         }
 
@@ -454,10 +463,11 @@ impl ReserveTrackerContract {
         current
     }
 
-    /// Upgrade the contract WASM to `new_wasm_hash` and bump the stored version to
-    /// `new_version` (admin only). `new_version` must exceed the current version.
-    /// Runs any required migrations.
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
+    /// Stage a WASM upgrade to `new_wasm_hash`/`new_version` and start the
+    /// upgrade timelock (admin only). `new_version` must exceed the current
+    /// version. Apply later with [`Self::execute_upgrade`] or abort with
+    /// [`Self::cancel_upgrade`].
+    pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
         Self::check_admin(&env);
 
         let current_version = env
@@ -469,9 +479,66 @@ impl ReserveTrackerContract {
             env.panic_with_error(ReserveTrackerError::InvalidVersion);
         }
 
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        let eligible_at = env
+            .ledger()
+            .timestamp()
+            .checked_add(UPGRADE_TIMELOCK_SECONDS)
+            .expect("Overflow in upgrade timelock calculation");
 
-        // Run migrations
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.pending_upgrade_wasm, &new_wasm_hash);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.pending_upgrade_version, &new_version);
+        env.storage()
+            .instance()
+            .set(&DATA_KEY.pending_upgrade_eligible_at, &eligible_at);
+    }
+
+    /// Execute a previously proposed upgrade once its timelock has elapsed,
+    /// swapping in the staged WASM, running migrations and bumping the version
+    /// (admin only). Panics if none is pending or the timelock is still active.
+    pub fn execute_upgrade(env: Env) {
+        Self::check_admin(&env);
+
+        let wasm_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.pending_upgrade_wasm)
+            .unwrap_or_else(|| env.panic_with_error(ReserveTrackerError::NoPendingUpgrade));
+        let new_version: u32 = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.pending_upgrade_version)
+            .unwrap_or_else(|| env.panic_with_error(ReserveTrackerError::NoPendingUpgrade));
+        let eligible_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DATA_KEY.pending_upgrade_eligible_at)
+            .unwrap_or(u64::MAX);
+        if env.ledger().timestamp() < eligible_at {
+            env.panic_with_error(ReserveTrackerError::TimelockNotElapsed);
+        }
+
+        let current_version = env
+            .storage()
+            .instance()
+            .get(&SharedDataKey::Version)
+            .unwrap_or(0);
+
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_wasm);
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_version);
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_eligible_at);
+
+        env.deployer().update_current_contract_wasm(wasm_hash);
+
         for v in current_version..new_version {
             match v {
                 0 => shared::migrate_v0_to_v1(&env),
@@ -482,6 +549,21 @@ impl ReserveTrackerContract {
         env.storage()
             .instance()
             .set(&SharedDataKey::Version, &new_version);
+    }
+
+    /// Cancel a pending upgrade, clearing the staged WASM hash, version and
+    /// timelock (admin only).
+    pub fn cancel_upgrade(env: Env) {
+        Self::check_admin(&env);
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_wasm);
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_version);
+        env.storage()
+            .instance()
+            .remove(&DATA_KEY.pending_upgrade_eligible_at);
     }
 
     // -----------------------------------------------------------------------

--- a/acbu_savings_vault/src/lib.rs
+++ b/acbu_savings_vault/src/lib.rs
@@ -789,7 +789,7 @@ impl SavingsVault {
             .storage()
             .instance()
             .get(&DATA_KEY.pending_admin)
-            .unwrap_or_else(|| env.panic_with_error(Error::NoAdmin));
+            .unwrap_or_else(|| env.panic_with_error(Error::NoPendingAdmin));
         pending_admin.require_auth();
 
         let eligible_at: u64 = env
@@ -798,7 +798,7 @@ impl SavingsVault {
             .get(&DATA_KEY.pending_admin_eligible_at)
             .unwrap_or(u64::MAX);
         if env.ledger().timestamp() < eligible_at {
-            env.panic_with_error(Error::TimelockNotElapsed);
+            env.panic_with_error(Error::AdminTimelockNotElapsed);
         }
 
         let old_admin = Self::load_admin(&env).unwrap_or_else(|e| env.panic_with_error(e));
@@ -823,7 +823,7 @@ impl SavingsVault {
             .storage()
             .instance()
             .get(&DATA_KEY.pending_admin)
-            .unwrap_or_else(|| env.panic_with_error(Error::NoAdmin));
+            .unwrap_or_else(|| env.panic_with_error(Error::NoPendingAdminToCancel));
         env.storage().instance().remove(&DATA_KEY.pending_admin);
         env.storage()
             .instance()


### PR DESCRIPTION
Fixes 4 audit issues:

**#471 (HIGH):** Wrong error codes in `acbu_savings_vault` `accept_admin` and `cancel_admin_transfer`
- `accept_admin`: `NoAdmin` → `NoPendingAdmin`, `TimelockNotElapsed` → `AdminTimelockNotElapsed`
- `cancel_admin_transfer`: `NoAdmin` → `NoPendingAdminToCancel`

**#472 (MEDIUM):** Interest collected but never distributed to lender in `acbu_lending_pool`
- Transfer the interest portion of repayment to the lender after borrower repays

**#473 (MEDIUM):** Rate-limited `verify_reserves` returns cached (possibly false) result during cooldown
- Return `true` during cooldown instead of cached result to prevent false "insufficient reserves" errors

**#474 (MEDIUM):** `acbu_reserve_tracker` upgrade has no timelock (inconsistent with other contracts)
- Replace single `upgrade` function with `propose_upgrade`/`execute_upgrade`/`cancel_upgrade` pattern using 24h timelock

Closes #471, Closes #472, Closes #473, Closes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-step, time-delayed upgrade process with options to propose, execute, or cancel upgrades.
  * Interest accrued on loans is now paid to lenders during repayment.
* **Bug Fixes**
  * Reserve verification now returns an immediate successful result during its cooldown period.
  * Improved admin-rotation error handling with clearer messages for missing or unavailable actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->