### PR TITLE
implemented

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -52,6 +52,13 @@ contractmeta!(key = "version", val = "1");
 /// or malicious transfer.
 const ADMIN_TIMELOCK_SECONDS: u64 = 86_400;
 
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PauseEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
 #[contract]
 pub struct BurningContract;
 
@@ -500,6 +507,29 @@ impl BurningContract {
         env.storage().instance().get(&DATA_KEY.admin).unwrap()
     }
 
+    /// Pause the contract, disabling all redemption operations (admin only).
+    pub fn pause(env: Env) {
+        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&DATA_KEY.phase, &ContractPhase::Paused);
+        let event = PauseEvent {
+            admin,
+            timestamp: env.ledger().timestamp(),
+        };
+        env.events().publish((symbol_short!("paused"),), event);
+    }
+
+    /// Unpause the contract, re-enabling redemption operations (admin only).
+    pub fn unpause(env: Env) {
+        let admin: Address = env.storage().instance().get(&DATA_KEY.admin).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&DATA_KEY.phase, &ContractPhase::Active);
+        let event = PauseEvent {
+            admin,
+            timestamp: env.ledger().timestamp(),
+        };
+        env.events().publish((symbol_short!("unpaused"),), event);
+    }
 
     /// Returns the pending admin address if a transfer is in progress.
     pub fn get_pending_admin(env: Env) -> Option<Address> {


### PR DESCRIPTION
Done. Here's what was implemented on branch `fix/burning-add-pause-unpause`:

**Added to `acbu_burning/src/lib.rs`:**

1. **`PauseEvent` struct** (line 55-60) — event type with `admin` and `timestamp`, matching the pattern in `acbu_minting`.

2. **`pause()` function** (line 510-520) — admin-only, sets phase to `ContractPhase::Paused`, emits `paused` event.

3. **`unpause()` function** (line 522-532) — admin-only, sets phase to `ContractPhase::Active`, emits `unpaused` event.

Both functions follow the exact same pattern used in `acbu_minting`, `acbu_lending_pool`, `acbu_escrow`, and `acbu_savings_vault`. The existing `check_paused()` at line 686 already correctly reads the phase from storage and only panics when `ContractPhase::Paused` — so with `pause()`/`unpause()` now available, the full pause lifecycle is functional.

**Note:** The repo has 6 pre-existing build errors (4 missing `check_oracle_freshness` imports + 2 type mismatches) that exist on `dev` before my changes. My additions introduce zero new errors.

Closes #466
Closes #464
Closes #467
Closes #465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-controlled pause and resume functionality.
  * Redemption operations are blocked while the contract is paused.
  * Pause and resume actions now emit timestamped events for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->