### PR TITLE
fix: emit correct term_seconds in LoanCreatedEvent

### DIFF
--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -27,6 +27,8 @@ pub enum DataKey {
 }
 
 const VERSION: u32 = CONTRACT_VERSION;
+/// Duration of a loan in seconds (30 days).
+const LOAN_TERM_SECONDS: u64 = 30 * 24 * 60 * 60;
 const UPGRADE_TIMELOCK_SECONDS: u64 = 86_400;
 /// TTL extension applied to instance storage on every public entry-point call
 /// (≈60 days at ~5-second ledger close time).
@@ -410,7 +412,7 @@ impl LendingPool {
             interest_rate_bps: u32::try_from(fee_rate_bps)
                 .unwrap_or_else(|_| env.panic_with_error(Error::InvalidAmount)),
             loan_start_timestamp: start_time,
-            repayment_deadline: start_time + (30 * 24 * 60 * 60),
+            repayment_deadline: start_time + LOAN_TERM_SECONDS,
             accrued_interest: 0,
             total_repayment_due: amount,
             status: LoanStatus::Active,
@@ -451,7 +453,7 @@ impl LendingPool {
                 borrower,
                 amount,
                 interest_bps: fee_rate,
-                term_seconds: 0,
+                term_seconds: LOAN_TERM_SECONDS,
                 timestamp,
             },
         );

--- a/acbu_lending_pool/tests/test_comprehensive.rs
+++ b/acbu_lending_pool/tests/test_comprehensive.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 
-use acbu_lending_pool::{BorrowEvent, LendingPool, LendingPoolClient, LoanStatus, RepayEvent};
+use acbu_lending_pool::{
+    BorrowEvent, LoanCreatedEvent, LendingPool, LendingPoolClient, LoanStatus, RepayEvent,
+};
 use shared::DECIMALS;
 use soroban_sdk::{
     symbol_short,
@@ -697,4 +699,62 @@ fn test_borrow_negative_amount_fails() {
 
     let result = client.try_borrow(&borrower, &lender, &-100, &1u64);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_loan_created_event_has_correct_term_seconds() {
+    let (env, client, contract_id, _admin, acbu_token) = setup();
+
+    let lender = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let pool_liquidity = 10_000 * DECIMALS;
+    let borrow_amount = 3_000 * DECIMALS;
+    let loan_id = 99u64;
+
+    let token_admin = StellarAssetClient::new(&env, &acbu_token);
+    token_admin.mint(&lender, &pool_liquidity);
+    client.deposit(&lender, &pool_liquidity);
+
+    let borrow_timestamp = env.ledger().timestamp();
+    client.borrow(&borrower, &lender, &borrow_amount, &loan_id);
+
+    let events = env.events().all();
+    let loan_created_event = events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.0 == contract_id
+                && e.1.first().map_or(false, |t| {
+                    if let Ok(symbol_val) =
+                        TryIntoVal::<_, Symbol>::try_into_val(&t, &env)
+                    {
+                        symbol_val == symbol_short!("loan_cr")
+                    } else {
+                        false
+                    }
+                })
+        })
+        .expect("loan_cr event not found");
+
+    let event_data: LoanCreatedEvent = loan_created_event.2.try_into_val(&env).unwrap();
+
+    assert_eq!(
+        event_data.term_seconds,
+        30 * 24 * 60 * 60,
+        "event.term_seconds should equal 30 days in seconds (2_592_000)"
+    );
+    assert_eq!(event_data.lender, lender, "event.lender should match");
+    assert_eq!(event_data.borrower, borrower, "event.borrower should match");
+    assert_eq!(
+        event_data.amount, borrow_amount,
+        "event.amount should match borrow_amount"
+    );
+    assert_eq!(
+        event_data.interest_bps, 300,
+        "event.interest_bps should match fee_rate (300)"
+    );
+    assert_eq!(
+        event_data.timestamp, borrow_timestamp,
+        "event.timestamp should match borrow timestamp"
+    );
 }


### PR DESCRIPTION


## Summary

Fixes an issue where `LoanCreatedEvent` emitted `term_seconds: 0` even though loans have a 30-day repayment period.

This caused off-chain indexers to receive incorrect loan duration data and prevented accurate maturity calculations from event data.

Closes #475 

## Changes

- Added `LOAN_TERM_SECONDS` constant for the 30-day loan duration.
- Updated loan creation logic to use the shared constant for `repayment_deadline`.
- Updated `LoanCreatedEvent.term_seconds` to emit the correct duration instead of `0`.
- Added regression coverage to verify emitted event fields.

## Tests

Added:

- `test_loan_created_event_has_correct_term_seconds`

Verifies:
- `term_seconds`
- lender
- borrower
- amount
- interest rate
- timestamp

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p acbu_lending_pool`


## Impact

- No storage changes.
- No API changes.
- No migration required.
- Existing loan state remains unaffected.

This is a targeted event-data fix only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loan creation events now report the correct 30-day repayment term.
  * Repayment deadlines are consistently calculated using the configured loan term.

* **Tests**
  * Added coverage verifying loan event details, including term, participants, amount, interest, and timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->