### PR TITLE
fix(oracle): use consistent storage key for version in migrate

### DIFF
--- a/acbu_oracle/src/lib.rs
+++ b/acbu_oracle/src/lib.rs
@@ -909,7 +909,11 @@ impl OracleContract {
     pub fn migrate(env: Env) {
         Self::check_admin(&env);
         let current_version = VERSION;
-        let stored_version: u32 = env.storage().instance().get(&DATA_KEY.version).unwrap_or(0);
+        let stored_version: u32 = env
+            .storage()
+            .instance()
+            .get(&SharedDataKey::Version)
+            .unwrap_or(0);
         if stored_version < current_version {
             if stored_version < 2 {
                 let s_tokens_empty: Map<CurrencyCode, Address> = Map::new(&env);
@@ -943,7 +947,7 @@ impl OracleContract {
             }
             env.storage()
                 .instance()
-                .set(&DATA_KEY.version, &current_version);
+                .set(&SharedDataKey::Version, &current_version);
         }
     }
 


### PR DESCRIPTION
## Summary
- `initialize()` and `finalize_upgrade()` write the contract version under the shared `SharedDataKey::Version` key, but `migrate()` was reading/writing a separate, unrelated `DATA_KEY.version` symbol.
- Because of this, `migrate()` always saw `stored_version == 0` and re-ran every migration branch on every call, re-initializing `s_tokens`, `rates`, `currencies`, and `basket_weights` each time.
- `migrate()` now reads and writes `SharedDataKey::Version`, matching `get_version()` and the rest of the upgrade path.

Fixes #468

## Test plan
- [x] `rustfmt --check` on the changed file (parses cleanly, no formatting diff)
- [ ] `cargo test -p acbu_oracle` — could not run in this environment: the `dev` branch currently fails to build against the pinned `soroban-sdk = "=21.7.7"` in the workspace `Cargo.toml`, because a separate, already-merged commit added `#[contractevent]` usage that isn't available until `soroban-sdk` 23.0.3+. This is a pre-existing, unrelated issue and reproduces on `dev` without any of this PR's changes; flagging separately rather than bundling an unrelated dependency bump into this fix.