### PR TITLE
fix(shared): assert guard is held in release_guard before clearing

### DIFF
--- a/shared/src/reentrancy_guard.rs
+++ b/shared/src/reentrancy_guard.rs
@@ -38,9 +38,14 @@ pub fn acquire_guard(env: &Env) {
 }
 
 /// Release the re-entrancy guard
-/// This must be called at the end of any function that acquired the guard
-/// Typically called in a drop guard or at the end of the function
+/// This must be called at the end of any function that acquired the guard.
+/// Panics if the guard is not currently held, preventing a caller from
+/// accidentally releasing a guard it never acquired (which would clear a
+/// legitimate outer guard prematurely).
 pub fn release_guard(env: &Env) {
+    if !env.storage().instance().has(&REENTRANCY_GUARD_KEY) {
+        env.panic_with_error(ReentrancyError::ReentrantCall);
+    }
     env.storage().instance().remove(&REENTRANCY_GUARD_KEY);
 }
 


### PR DESCRIPTION
## Summary

`release_guard()` in `shared/src/reentrancy_guard.rs` was unconditionally calling `env.storage().instance().remove()` without first verifying that the guard was actually set. This means any caller that invokes `release_guard()` without a matching `acquire_guard()` would silently clear a legitimate outer guard held by another function — a premature guard release.

While not currently reachable in the existing call graph, this is a correctness bug waiting to happen: if `redeem_basket` (or any future function) were called from within another guarded function, the outer guard would be cleared prematurely, defeating the reentrancy protection entirely.

## Changes

**`shared/src/reentrancy_guard.rs`**
- Added a `has()` check in `release_guard()` before calling `remove()`
- If the guard is **not** held when `release_guard()` is called, panics with `ReentrancyError::ReentrantCall` (error 6001) — the same error used for detected reentrancy
- Updated the doc comment to document the new invariant

This makes `release_guard()` symmetric with `acquire_guard()`: both assert the expected state before mutating it.

## Impact

- All existing call sites that correctly pair `acquire_guard()` / `release_guard()` are unaffected
- Any future function that calls `release_guard()` without holding the guard will panic immediately and deterministically, rather than silently corrupting reentrancy state

Closes #534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved re-entrancy protection by detecting invalid guard releases.
  * Prevents accidental removal of an active re-entrancy guard and reports an appropriate error instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->