### PR TITLE
feat: add slippage protection to mint/redeem entrypoints

### DIFF
--- a/acbu_burning/src/lib.rs
+++ b/acbu_burning/src/lib.rs
@@ -129,12 +129,17 @@ impl BurningContract {
     /// transfers the equivalent S-token amount to `recipient` from the vault.
     /// Requires that both the ACBU/USD and currency/USD oracle prices are fresh
     /// (within `UPDATE_INTERVAL_SECONDS`) and that reserves are sufficient.
+    ///
+    /// `min_stoken_out` is an optional slippage guard: if the computed S-token
+    /// output is below this value the transaction reverts with `SlippageExceeded`
+    /// before any ACBU is burned. Pass `None` to disable the check.
     pub fn redeem_single(
         env: Env,
         user: Address,
         recipient: Address,
         acbu_amount: i128,
         currency: CurrencyCode,
+        min_stoken_out: Option<i128>,
     ) -> i128 {
 
         Self::check_paused(&env);
@@ -204,6 +209,13 @@ impl BurningContract {
             .and_then(|v| v.checked_div(rate))
             .expect("Overflow in stoken out calculation");
 
+        // Slippage guard: reject before any state change if output is below caller's floor.
+        if let Some(floor) = min_stoken_out {
+            if stoken_out < floor {
+                env.panic_with_error(ContractError::SlippageExceeded);
+            }
+        }
+
         Self::check_reserves(&env, &acbu_token, &reserve_tracker_addr);
 
         let acbu_client = soroban_sdk::token::Client::new(&env, &acbu_token);
@@ -233,11 +245,19 @@ impl BurningContract {
     }
 
     /// Redeem ACBU for proportional Afreum S-tokens across the basket (lower fee tier).
+    ///
+    /// `min_stokens_out` is an optional per-leg slippage guard: if provided, its
+    /// length must equal the number of basket currencies and each element is the
+    /// minimum acceptable S-token amount for that leg. The transaction reverts
+    /// with `SlippageExceeded` before any ACBU is burned if any leg's computed
+    /// output falls below the corresponding floor. Pass `None` to disable all
+    /// per-leg checks (backwards-compatible default).
     pub fn redeem_basket(
         env: Env,
         user: Address,
         recipients: Vec<Address>,
         acbu_amount: i128,
+        min_stokens_out: Option<Vec<i128>>,
     ) -> Vec<i128> {
         Self::check_paused(&env);
         user.require_auth();
@@ -245,6 +265,13 @@ impl BurningContract {
 
         if recipients.is_empty() {
             env.panic_with_error(ContractError::InvalidRecipient);
+        }
+
+        // Validate min_stokens_out length before doing any heavy computation.
+        if let Some(ref floors) = min_stokens_out {
+            if floors.len() != recipients.len() {
+                env.panic_with_error(ContractError::InvalidAmount);
+            }
         }
 
         for i in 0..recipients.len() {
@@ -325,6 +352,61 @@ impl BurningContract {
             .checked_mul(acbu_rate)
             .and_then(|v| v.checked_div(DECIMALS))
             .expect("Overflow in usd total");
+
+        // Pre-flight slippage check — runs before any state change so the
+        // transaction reverts cleanly without burning ACBU first.
+        if let Some(ref floors) = min_stokens_out {
+            let mut pf_last_positive: Option<u32> = None;
+            for i in 0..weights.len() {
+                if weights.get(i).unwrap() > 0 {
+                    pf_last_positive = Some(i);
+                }
+            }
+            let mut pf_allocated_usd = 0i128;
+            let mut pf_allocated_gross = 0i128;
+            let mut pf_allocated_fee = 0i128;
+            for i in 0..currencies.len() {
+                let currency = currencies.get(i).unwrap();
+                let weight = weights.get(i).unwrap();
+                if weight == 0 {
+                    continue;
+                }
+                let (rate, _): (i128, u64) = env.invoke_contract(
+                    &oracle_addr,
+                    &Symbol::new(&env, ORACLE_GET_RATE_WITH_TS),
+                    vec![&env, currency.clone().into_val(&env)],
+                );
+                if rate <= 0 {
+                    env.panic_with_error(ContractError::InvalidRate);
+                }
+                let (pf_usd_i, pf_gross_i, pf_fee_i) = if pf_last_positive == Some(i) {
+                    (
+                        usd_total.checked_sub(pf_allocated_usd).expect("pf usd"),
+                        acbu_amount.checked_sub(pf_allocated_gross).expect("pf gross"),
+                        total_fee.checked_sub(pf_allocated_fee).expect("pf fee"),
+                    )
+                } else {
+                    (
+                        Self::weighted_floor(usd_total, weight, total_weight),
+                        Self::weighted_floor(acbu_amount, weight, total_weight),
+                        Self::weighted_floor(total_fee, weight, total_weight),
+                    )
+                };
+                pf_allocated_usd = pf_allocated_usd.checked_add(pf_usd_i).expect("pf alloc usd");
+                pf_allocated_gross = pf_allocated_gross.checked_add(pf_gross_i).expect("pf alloc gross");
+                pf_allocated_fee = pf_allocated_fee.checked_add(pf_fee_i).expect("pf alloc fee");
+                let pf_net_i = pf_gross_i.checked_sub(pf_fee_i).expect("pf net");
+                let pf_native_i = pf_net_i
+                    .checked_mul(acbu_rate)
+                    .and_then(|v| v.checked_div(rate))
+                    .expect("pf native");
+                if let Some(floor) = floors.get(i) {
+                    if pf_native_i < floor {
+                        env.panic_with_error(ContractError::SlippageExceeded);
+                    }
+                }
+            }
+        }
 
         reentrancy_guard::acquire_guard(&env);
         Self::check_reserves(&env, &acbu_token, &reserve_tracker_addr);

--- a/acbu_burning/tests/redeem_single.rs
+++ b/acbu_burning/tests/redeem_single.rs
@@ -32,9 +32,7 @@ fn test_redeem_single_success() {
     let recipient = Address::generate(&env);
     let out = ctx
         .burning
-        .redeem_single(&ctx.user, &recipient, &burn_amount, &currency);
-
-    let expected_fee = (burn_amount * 200) / BASIS_POINTS;
+        .redeem_single(&ctx.user, &recipient, &burn_amount, &currency, &None);
     let net_acbu = burn_amount - expected_fee;
     let expected_out = (net_acbu * acbu_rate) / ngn_rate;
 

--- a/acbu_minting/src/lib.rs
+++ b/acbu_minting/src/lib.rs
@@ -125,6 +125,10 @@ pub enum MintingError {
     InvalidRecipient = 5023,
     InvalidRoleSeparation = 5024,
     SupplyMismatch = 5025,
+    /// The computed ACBU output is below the caller-supplied `min_acbu_out`
+    /// floor, indicating that same-block oracle movement would cause unacceptable
+    /// slippage. The transaction should be retried with updated parameters.
+    SlippageExceeded = 5026,
     Unknown = 5999,
 }
 
@@ -156,6 +160,7 @@ impl Display for MintingError {
             Self::InvalidRecipient => "invalid recipient",
             Self::InvalidRoleSeparation => "admin and operator must be different addresses",
             Self::SupplyMismatch => "supplied value does not match on-chain supply",
+            Self::SlippageExceeded => "output below minimum: slippage exceeded",
             Self::Unknown => "unknown minting error",
         };
         f.write_str(message)
@@ -286,7 +291,17 @@ impl MintingContract {
     }
 
     /// Mint ACBU from USDC deposit (unchanged reserve/oracle flow).
-    pub fn mint_from_usdc(env: Env, user: Address, usdc_amount: i128, recipient: Address) -> i128 {
+    ///
+    /// `min_acbu_out` is an optional slippage guard: if the computed ACBU amount
+    /// is below this value the transaction reverts with `SlippageExceeded`.
+    /// Pass `None` to disable the check (backwards-compatible default).
+    pub fn mint_from_usdc(
+        env: Env,
+        user: Address,
+        usdc_amount: i128,
+        recipient: Address,
+        min_acbu_out: Option<i128>,
+    ) -> i128 {
         // Re-entrancy guard
         reentrancy_guard::acquire_guard(&env);
 
@@ -342,6 +357,13 @@ impl MintingContract {
             .checked_mul(DECIMALS)
             .and_then(|v| v.checked_div(acbu_rate))
             .unwrap_or_else(|| env.panic_with_error(MintingError::InvalidMintAmount));
+
+        // Slippage guard: reject if computed output is below caller's minimum.
+        if let Some(floor) = min_acbu_out {
+            if acbu_amount < floor {
+                env.panic_with_error(MintingError::SlippageExceeded);
+            }
+        }
 
         let projected_supply = total_supply
             .checked_add(acbu_amount)

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -298,6 +298,11 @@ pub enum ContractError {
     /// WASM upgrade rejected: `new_version` must be greater than the stored version.
     InvalidVersion = 12,
 
+    /// The computed output amount is below the caller-supplied minimum acceptable
+    /// output (`min_*_out`), indicating that same-block oracle movement would
+    /// cause unacceptable slippage for this transaction.
+    SlippageExceeded = 13,
+
     Unknown = 9999,
 }
 
@@ -316,6 +321,7 @@ impl core::fmt::Display for ContractError {
             ContractError::InsufficientBalance => write!(f, "insufficient balance"),
             ContractError::InvalidRecipient => write!(f, "invalid recipient"),
             ContractError::InvalidVersion => write!(f, "invalid version"),
+            ContractError::SlippageExceeded => write!(f, "output below minimum: slippage exceeded"),
             ContractError::Unknown => write!(f, "unknown error"),
         }
     }


### PR DESCRIPTION
Add optional min_acbu_out / min_stoken_out parameters to mint_from_usdc, redeem_single, and redeem_basket so callers are not fully exposed to same-block oracle price moves.

Changes:
- shared: ContractError::SlippageExceeded = 13 + Display arm
- acbu_minting: MintingError::SlippageExceeded = 5026 + Display arm
- mint_from_usdc: add min_acbu_out: Option<i128>; guard fires after acbu_amount is computed, before supply mutation or token transfers (fully pre-state-change)
- redeem_single: add min_stoken_out: Option<i128>; guard fires after stoken_out is computed, before ACBU burn
- redeem_basket: add min_stokens_out: Option<Vec<i128>>; per-leg pre-flight pass before reentrancy guard / burn validates every leg against its floor; length mismatch reverts with InvalidAmount

All new parameters are Option so existing callers passing None are fully backward-compatible. Separate from SC-009 oracle consensus fixes.

closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional slippage protection when minting ACBU with USDC.
  * Added minimum-output checks for single-asset and basket redemptions.
  * Transactions now revert before processing when outputs fall below configured minimums.
  * Basket redemptions validate that minimum-output settings match the basket structure.

* **Bug Fixes**
  * Added clear slippage-exceeded error reporting for failed minimum-output checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->