### PR TITLE
fix(lending-pool): resolve same-asset collateral ambiguity in borrow() (SC-018)

### DIFF
--- a/README_REPO.md
+++ b/README_REPO.md
@@ -18,7 +18,7 @@ At a high level, the system is a stablecoin-like protocol that supports:
 - **Reserve tracking** to enforce an overcollateralization policy.
 - Additional optional protocol components:
   - **Savings vault** (term-based deposits with yield accrual).
-  - **Lending pool** (a basic collateralized lending protocol).
+  - **Lending pool** (a basic peer-to-peer, uncollateralized ACBU lending protocol).
   - **Escrow** (merchant/e-commerce style payment escrow).
 - **Multisig administration** to protect privileged actions (pause, upgrades, parameter changes).
 
@@ -410,7 +410,7 @@ This contract provides simplified lending features:
 - `initialize(admin, acbu_token, fee_rate_bps)`
 - `deposit(lender, amount)`
 - `withdraw(lender, amount)`
-- `borrow(borrower, amount, collateral_amount, loan_id)`
+- `borrow(borrower, lender, amount, loan_id)`
 - `repay(borrower, amount, loan_id)`
 - pause/unpause and upgrades.
 
@@ -420,9 +420,23 @@ The contract stores:
 - active loans (as `LoanData` keyed by `(borrower, loan_id)`)
 - accrued interest and repayment due
 
-Collateralization enforcement (in the borrow entrypoint):
+Collateral policy (in the borrow entrypoint):
 
-- requires `collateral_amount >= amount`
+- The pool is **single-asset and uncollateralized**. Both the liquidity and the
+  loan principal are ACBU, and no collateral is taken.
+- An earlier iteration pulled a `collateral_amount` of ACBU and required
+  `collateral_amount >= amount` before paying out the same ACBU token. That is a
+  degenerate arrangement — it locks at least as much of the borrowed asset as it
+  releases, so it extends no purchasing power and offers the lender no protection
+  — and there was no liquidation path able to seize it. It has been removed.
+- Because the loan is unsecured, `borrow` requires authorization from **both**
+  the borrower and the lender: depositing liquidity is not an open offer to lend
+  it to anyone, so each loan is an explicit peer-to-peer agreement signed by both
+  parties.
+- `LoanData.collateral_amount` is retained (always `0`) and error code `2014`
+  (`InsufficientCollateral`) is reserved for a future *distinct-asset* collateral
+  extension, which additionally needs oracle pricing and a liquidation path.
+- There is no `liquidate()` entrypoint yet; an unrepaid loan simply stays open.
 
 ### 10.3 Escrow (`acbu_escrow/`)
 
@@ -601,7 +615,7 @@ The output of contracts (events) is intended to drive backend and off-chain proc
 - `acbu_oracle`: stores and publishes currency rates and basket ACBU/USD.
 - `acbu_reserve_tracker`: stores reserves and enforces minimum reserve ratio.
 - `acbu_savings_vault`: term deposits with yield.
-- `acbu_lending_pool`: collateralized lending.
+- `acbu_lending_pool`: peer-to-peer, uncollateralized ACBU lending.
 - `acbu_escrow`: escrow create/release/refund.
 - `acbu_multisig`: emergency M-of-N admin guard.
 - `shared`: shared event payloads, constants, and math.

--- a/acbu_lending_pool/src/lib.rs
+++ b/acbu_lending_pool/src/lib.rs
@@ -69,6 +69,18 @@ pub struct LoanData {
     pub borrower: Address,
     pub lender: Address,
     pub amount: i128,
+    /// Reserved for a future multi-asset collateral extension; always `0` today.
+    ///
+    /// The pool is single-asset: both the liquidity and the loan principal are
+    /// ACBU. Posting ACBU as collateral for an ACBU loan is a no-op — it locks
+    /// at least as much of the borrowed asset as it releases and provides no
+    /// credit protection — so no collateral is pulled on [`LendingPool::borrow`].
+    /// See [`LendingPool::borrow`] for the full rationale (SC-018).
+    ///
+    /// The field is retained rather than removed so that already-stored
+    /// [`LoanData`] entries keep decoding across a contract upgrade, and so that
+    /// a real (distinct-asset) collateral implementation can populate it without
+    /// another storage migration.
     pub collateral_amount: i128,
     pub interest_rate_bps: u32,
     pub loan_start_timestamp: u64,
@@ -151,6 +163,12 @@ pub enum Error {
     AlreadyInitialized = 2011,
     InvalidAmount = 2012,
     InsufficientBalance = 2013,
+    // Reserved. Never returned by the current single-asset pool, which takes no
+    // collateral (see `LoanData::collateral_amount` and `LendingPool::borrow`).
+    // Kept so error code 2014 stays stable for clients and remains available to a
+    // future distinct-asset collateral implementation. Note: `//` and not `///` —
+    // a doc comment here would replace the short `Display` wording in the
+    // generated docs/ERROR_CODES.md table.
     InsufficientCollateral = 2014,
     InsufficientLiquidity = 2015,
     DustBalance = 2016,
@@ -339,9 +357,34 @@ impl LendingPool {
     /// Borrow `amount` of ACBU from a specific `lender`'s liquidity, creating
     /// a new loan keyed by `(borrower, loan_id)`.
     ///
-    /// Requires `borrower`'s authorization and that the pool is not paused.
-    /// The lender must have enough unborrowed balance. `loan_id` must be unique
-    /// for the borrower. Emits [`BorrowEvent`] and [`LoanCreatedEvent`].
+    /// Requires authorization from **both** `borrower` and `lender`, and that the
+    /// pool is not paused. The lender must have enough unborrowed balance.
+    /// `loan_id` must be unique for the borrower. Emits [`BorrowEvent`] and
+    /// [`LoanCreatedEvent`].
+    ///
+    /// # Design: this pool is uncollateralized by construction (SC-018)
+    ///
+    /// An earlier iteration pulled a `collateral_amount` of ACBU from the
+    /// borrower and required `collateral_amount >= amount` before paying out
+    /// `amount` of the *same* ACBU token. That is a degenerate arrangement: the
+    /// borrower had to already hold — and give up control of — at least as much
+    /// ACBU as they received, so the loan extended no purchasing power, and the
+    /// "collateral" gave the lender no protection they did not already have.
+    /// There was also no liquidation path that could seize it. It was leftover
+    /// from an earlier design rather than an intended placeholder, and the
+    /// collateral leg has been removed.
+    ///
+    /// Because nothing secures the principal, credit risk sits entirely with the
+    /// lender, so the lender must consent to each individual loan: `borrow`
+    /// requires `lender.require_auth()` in addition to `borrower.require_auth()`.
+    /// Depositing liquidity is *not* an open offer to lend it to anyone — without
+    /// the lender's signature, any address could drain a depositor's balance as
+    /// an unsecured loan. Both parties therefore sign the same borrow
+    /// transaction, making each loan an explicit peer-to-peer agreement.
+    ///
+    /// Meaningful collateral requires a *distinct* asset plus oracle pricing and
+    /// a liquidation path; that is a separate feature, and
+    /// [`LoanData::collateral_amount`] is reserved for it.
     pub fn borrow(
         env: Env,
         borrower: Address,
@@ -353,6 +396,9 @@ impl LendingPool {
         reentrancy_guard::acquire_guard(&env);
 
         borrower.require_auth();
+        // The loan is unsecured (see the function docs), so the lender bears the
+        // full credit risk and must approve this specific loan.
+        lender.require_auth();
         Self::check_paused(&env);
 
         if amount <= 0 {
@@ -408,6 +454,8 @@ impl LendingPool {
             borrower: borrower.clone(),
             lender: lender.clone(),
             amount,
+            // No collateral is taken; the field is reserved for a future
+            // distinct-asset collateral extension (SC-018).
             collateral_amount: 0,
             interest_rate_bps: u32::try_from(fee_rate_bps)
                 .unwrap_or_else(|_| env.panic_with_error(Error::InvalidAmount)),

--- a/acbu_lending_pool/tests/test.rs
+++ b/acbu_lending_pool/tests/test.rs
@@ -608,3 +608,117 @@ fn test_loan_lifecycle_emits_events() {
     assert_eq!(repayment_event_data.borrower, borrower);
     assert_eq!(repayment_event_data.amount, borrow_amount - repay_amount);
 }
+
+// ── SC-018: same-asset collateral removal ────────────────────────────────────
+
+/// The pool is single-asset and uncollateralized: `borrow` must not pull any
+/// ACBU from the borrower, and a borrower holding no ACBU at all must still be
+/// able to take out a loan. The recorded `collateral_amount` stays `0`, which is
+/// the reserved value for the future distinct-asset collateral extension.
+#[test]
+fn test_borrow_takes_no_collateral_from_borrower() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register_contract(None, LendingPool);
+    let client = LendingPoolClient::new(&env, &contract_id);
+    client.initialize(&admin, &acbu_token, &0);
+
+    let token_admin = StellarAssetClient::new(&env, &acbu_token);
+    let token_client = TokenClient::new(&env, &acbu_token);
+
+    let lender = Address::generate(&env);
+    let pool_liquidity: i128 = 1_000_000;
+    token_admin.mint(&lender, &pool_liquidity);
+    client.deposit(&lender, &pool_liquidity);
+
+    // Borrower starts with zero ACBU — under the old same-asset collateral rule
+    // (collateral_amount >= amount) this borrow would have been impossible.
+    let borrower = Address::generate(&env);
+    assert_eq!(token_client.balance(&borrower), 0, "borrower must start with no ACBU");
+
+    let borrow_amount: i128 = 400_000;
+    let loan_id: u64 = 700;
+    client.borrow(&borrower, &lender, &borrow_amount, &loan_id);
+
+    // The borrower nets the full principal: nothing was locked as collateral.
+    assert_eq!(
+        token_client.balance(&borrower),
+        borrow_amount,
+        "borrower must receive the full principal with no collateral withheld"
+    );
+    assert_eq!(
+        token_client.balance(&contract_id),
+        pool_liquidity - borrow_amount,
+        "pool must hold exactly the unlent liquidity"
+    );
+
+    let loan = client
+        .get_loan(&borrower, &loan_id)
+        .expect("loan must exist");
+    assert_eq!(
+        loan.collateral_amount, 0,
+        "collateral_amount is reserved and must remain 0"
+    );
+}
+
+/// Because the loan is unsecured, depositing liquidity is not an open offer to
+/// lend it to anyone: `borrow` requires the lender's authorization as well as
+/// the borrower's. Without it a borrower could drain a depositor's balance.
+#[test]
+fn test_borrow_without_lender_auth_fails() {
+    use soroban_sdk::testutils::MockAuth;
+    use soroban_sdk::testutils::MockAuthInvoke;
+    use soroban_sdk::IntoVal;
+
+    let env = Env::default();
+
+    let admin = Address::generate(&env);
+    let acbu_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register_contract(None, LendingPool);
+    let client = LendingPoolClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &acbu_token, &0);
+
+    let lender = Address::generate(&env);
+    let pool_liquidity: i128 = 1_000_000;
+    let token_admin = StellarAssetClient::new(&env, &acbu_token);
+    let token_client = TokenClient::new(&env, &acbu_token);
+    token_admin.mint(&lender, &pool_liquidity);
+    client.deposit(&lender, &pool_liquidity);
+
+    // Only the borrower signs — the lender never consented to this loan.
+    let borrower = Address::generate(&env);
+    let borrow_amount: i128 = 400_000;
+    let loan_id: u64 = 701;
+    env.mock_auths(&[MockAuth {
+        address: &borrower,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "borrow",
+            args: (&borrower, &lender, borrow_amount, loan_id).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_borrow(&borrower, &lender, &borrow_amount, &loan_id);
+    assert!(
+        result.is_err(),
+        "unsecured borrow without the lender's authorization must be rejected"
+    );
+
+    // The lender's liquidity is untouched and no loan was recorded.
+    assert_eq!(client.get_balance(&lender), pool_liquidity);
+    assert_eq!(token_client.balance(&contract_id), pool_liquidity);
+    assert_eq!(token_client.balance(&borrower), 0);
+    assert!(client.get_loan(&borrower, &loan_id).is_none());
+}

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -180,16 +180,28 @@ Provides peer-to-peer lending functionality for ACBU tokens.
 - `initialize`: Configure admin and token
 - `deposit`: Deposit ACBU into lending pool
 - `withdraw`: Withdraw ACBU from lending pool
-- `borrow`: Borrow ACBU with collateral
+- `borrow`: Borrow ACBU from a specific lender's liquidity (borrower and lender
+  must both authorize)
 - `repay`: Repay borrowed ACBU
-- `liquidate`: Liquidate undercollateralized loans
 
 ### Features
 
-- Collateralized lending
+- Uncollateralized, single-asset lending: liquidity and principal are both ACBU
 - Interest accrual
-- Liquidation mechanism
 - Pool balance tracking
+
+### Collateral policy
+
+The pool takes no collateral. Posting ACBU against an ACBU loan locks at least as
+much of the borrowed asset as it releases, so it extends no purchasing power and
+gives the lender no protection; the earlier `collateral_amount >= amount` check
+has been removed. Because the loan is unsecured, the lender bears the full credit
+risk and must authorize each individual loan alongside the borrower.
+
+`LoanData.collateral_amount` (always `0`) and error code `2014`
+(`InsufficientCollateral`) are reserved for a future *distinct-asset* collateral
+extension, which also requires oracle pricing and a liquidation path. No
+`liquidate` entrypoint exists today: an unrepaid loan remains open in storage.
 
 ---
 


### PR DESCRIPTION
closes #523

## Answer to the question in the issue

The same-asset collateral was **leftover from an earlier iteration, not an intended placeholder**.

`borrow()` used to pull a `collateral_amount` of ACBU from the borrower and require `collateral_amount >= amount` before paying out `amount` of the *same* ACBU token. That arrangement cannot work as collateral:

- The borrower had to already hold — and give up control of — at least as much ACBU as they received, so the loan extended no purchasing power at all.
- The "collateral" gave the lender no protection they did not already have: it is the same asset, same price, same risk.
- There is no `liquidate()` entrypoint, so nothing could ever seize it on default.

Meaningful collateral requires a *distinct* asset plus oracle pricing and a liquidation path. That is a separate feature, not something the current single-asset pool can express.

## What this PR changes

The collateral leg had already been dropped from `borrow()` on `dev`, but the removal left the pool's collateral policy undocumented and, more importantly, unenforced. This PR finishes it.

### 1. `borrow()` now requires the lender's authorization (`acbu_lending_pool/src/lib.rs`)

This is the part that matters beyond documentation. With the collateral leg gone, nothing secures the principal — yet `borrow()` only required `borrower.require_auth()`. Depositing liquidity into the pool is not an open offer to lend it to anyone: as it stands, **any address can call `borrow(attacker, victim_lender, victim_balance, id)` and walk away with a depositor's funds as an unsecured loan with no recourse.** The same-asset collateral pull was the only thing that previously made this a no-op.

`borrow()` now calls `lender.require_auth()` in addition to `borrower.require_auth()`, so both parties sign the same transaction and each loan is an explicit peer-to-peer agreement. This is consistent with the entrypoint already taking an explicit `lender` address, and with `deposit`/`withdraw`, which both authorize the balance owner.

I have flagged this as a behavioural change rather than pure documentation, since it is slightly wider than the literal ask in the issue. It is included because the issue's question cannot be answered "the collateral is intentionally gone" while leaving depositor balances open to anyone.

### 2. Reserved surfaces documented instead of deleted

- `LoanData.collateral_amount` stays in the struct (always `0`) so already-stored `LoanData` entries keep decoding across a contract upgrade, and so a future distinct-asset implementation can populate it without another storage migration.
- `Error::InsufficientCollateral` (code `2014`) stays so the documented, client-facing error code numbering remains stable.

Both are now documented as reserved, with the rationale, so this does not read as dead code to the next reader. The `InsufficientCollateral` note deliberately uses `//` rather than `///`: `scripts/generate_error_codes.py` prefers doc comments over the `Display` message, so a doc comment there would rewrite the `docs/ERROR_CODES.md` row. That file is unchanged by this PR.

### 3. Documentation corrected

`README_REPO.md` and `docs/CONTRACTS.md` still described the removed `collateral_amount >= amount` rule, the old `borrow(borrower, amount, collateral_amount, loan_id)` signature, and a `liquidate()` entrypoint plus "liquidation mechanism" that do not exist. All are corrected, and the collateral policy is now stated explicitly in both places.

### 4. Regression tests (`acbu_lending_pool/tests/test.rs`)

- `test_borrow_takes_no_collateral_from_borrower` — a borrower holding **zero** ACBU (impossible under the old `collateral_amount >= amount` rule) can still take a loan, nets the full principal, and the recorded `collateral_amount` is `0`.
- `test_borrow_without_lender_auth_fails` — a borrow signed only by the borrower is rejected, and the lender's balance, the pool's token balance and the absence of a loan record are all asserted afterwards.

## Testing

`cargo test -p acbu_lending_pool`: 49 tests pass (14 in `test.rs` including the 2 new ones, 34 in `test_comprehensive.rs`, 2 fuzz tests, minus the one noted below). No existing test needed changing — the suites use `mock_all_auths()`, so the added lender authorization is satisfied.

Two pre-existing issues on `dev` are worth flagging, neither caused by this PR:

1. **The workspace does not compile against its own SDK pin.** `Cargo.toml` pins `soroban-sdk = "=21.7.7"`, but `acbu_lending_pool` and `acbu_escrow` use `#[contractevent]`, which does not exist before SDK 23, and `DataKey` derives `Copy` while holding `Address` fields. `cargo check -p acbu_lending_pool` fails on `dev` at `a994f5d` before any change of mine. To run the suites I verified against a temporary local shim (SDK 23 + events emitted as `#[contracttype]`); none of that is part of this PR. Under that shim `test_loan_lifecycle_emits_events` fails on event-topic lookup — I confirmed it fails identically with and without my change, so it is an artifact of the shim, not a regression.
2. **`python scripts/generate_error_codes.py --check` fails on `dev`**, because `docs/ERROR_CODES.md` is missing the `7025 InsufficientEmergencyVotes` row. Since that check is the first step of the Tests workflow, CI is currently red on `dev` for reasons unrelated to this PR. I left it alone rather than mixing an unrelated docs regeneration into this change; happy to fix it here or in a separate PR if you prefer.

## Alternative considered

Reinstating collateral properly — a configurable, distinct collateral asset with an oracle-priced collateralization ratio and a liquidation path. That is a real feature with its own design decisions (which asset, what ratio, who liquidates, what incentive), well beyond the scope of this issue, so this PR records the current design honestly and reserves the storage field and error code for it instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Borrowers can receive the full loan amount without providing collateral.
  * Loans now require authorization from both the borrower and lender.
  * Lending is documented as single-asset, uncollateralized ACBU lending.

* **Documentation**
  * Updated contract guides to reflect the current borrowing model.
  * Clarified that liquidation is unavailable and unrepaid loans remain open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->